### PR TITLE
Cleanup context.Background() usage

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -32,13 +32,14 @@ type serverSettings struct {
 }
 
 type dbSettings struct {
-	User           string `validate:"required"`
-	Password       string `validate:"required"`
-	DBName         string `validate:"required"`
-	Host           string `validate:"required"`
-	Port           int    `validate:"required"`
-	SSLMode        string `validate:"required"`
-	CACertFilename string `mapstructure:"ca_cert_filename"`
+	User           string        `validate:"required"`
+	Password       string        `validate:"required"`
+	DBName         string        `validate:"required"`
+	Host           string        `validate:"required"`
+	Port           int           `validate:"required"`
+	SSLMode        string        `validate:"required"`
+	CACertFilename string        `mapstructure:"ca_cert_filename"`
+	QueryTimeout   time.Duration `mapstructure:"query_timeout" validate:"required,gt=5s"`
 }
 
 type oidcSettings struct {

--- a/sunet-cdn-manager.toml.sample
+++ b/sunet-cdn-manager.toml.sample
@@ -10,6 +10,7 @@ host = "127.0.0.1"
 port = 5432
 sslmode = "verify-full"
 ca_cert_filename = ""
+query_timeout = "15s"
 
 [oidc]
 issuer = "https://keycloak.sunet-cdn.localhost:8443/realms/sunet-cdn-manager"


### PR DESCRIPTION
Now there are only a few initializations of context using context.Background() and most functions use either the request scoped context passed in to any further functions, or they use a detached context based on the request context but which wont be cancelled if the request context is cancelled. Instead it has its own timeout so we can finish database modifications even if the server is asked to stop in the middle of the request.

Modify the server write timeout to be dependent on the newly added query_timeout config option for DB operations so we will be prepared to wait 5 seconds more to write than we allow any detached database operation to take.

This should make the server be able to handle a misbehaving database backend in a much more controlled way rather than potentially hanging connections indefinitely.