### PR TITLE
Remove configurable argon2 settings

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -56,9 +56,6 @@ type keycloakClientAdminSettings struct {
 	ClientSecret   string `mapstructure:"client_secret" validate:"required"`
 	EncryptionKey  string `mapstructure:"encryption_key" validate:"required,min=15"`
 	EncryptionSalt string `mapstructure:"encryption_salt" validate:"required,len=32,hexadecimal"`
-	Argon2Time     uint32 `mapstructure:"argon2_time" validate:"required,gt=0"`
-	Argon2Memory   uint32 `mapstructure:"argon2_memory" validate:"required,gt=0"`
-	Argon2Threads  uint8  `mapstructure:"argon2_threads" validate:"required,gt=0"`
 }
 
 type domainSettings struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2253,6 +2253,8 @@ type argon2Settings struct {
 	argonTagSize uint32
 }
 
+// Keep in mind that if you change these values existing encryption keys
+// derived from these settings will not match anymore.
 func newArgon2DefaultSettings() argon2Settings {
 	argon2Settings := argon2Settings{}
 	// https://datatracker.ietf.org/doc/rfc9106/
@@ -2686,12 +2688,14 @@ func getClientCredEncryptionKey(conf config.Config) ([]byte, error) {
 		return nil, fmt.Errorf("getClientCredEncryptionKey: cannot decode salt hex: %w", err)
 	}
 
+	argon2Settings := newArgon2DefaultSettings()
+
 	return argon2.IDKey(
 		[]byte(conf.KeycloakClientAdmin.EncryptionKey),
 		salt,
-		conf.KeycloakClientAdmin.Argon2Time,
-		conf.KeycloakClientAdmin.Argon2Memory,
-		conf.KeycloakClientAdmin.Argon2Threads,
+		argon2Settings.argonTime,
+		argon2Settings.argonMemory,
+		argon2Settings.argonThreads,
 		chacha20poly1305.KeySize,
 	), nil
 }

--- a/sunet-cdn-manager.toml.sample
+++ b/sunet-cdn-manager.toml.sample
@@ -25,10 +25,6 @@ client_id = "sunet-cdn-manager-admin-client"
 client_secret = "some-secret"
 encryption_key = "some-secret-encryption-key"
 encryption_salt = "36023a78c7d2000ac58604da1b630a9f"
-argon2_time = 3
-argon2_memory = 65536
-argon2_threads = 4
-argon2_tag_size = 32
 
 [domains]
 resolver_address = "127.0.0.1:53"


### PR DESCRIPTION
For now stick with the settings that are available internally. If we ever want to modify these settings this needs to be done carefully since we currently do not track what settings was used when encrypting a given registration access token. Not doing that allows us to just compute the encryption key at startup, but if we start tracking the settings used for any given encrypted blob this means we need to potentially do expensive argon2 operations any time we try to decrypt data (or precompute all available combinations).

Skip that complexity for now until we have a need for it, and if that ever happens we probably want to be able to write a db migration that fills in existing settings in an updated db layout which is much simpler if we know what values has been used for existing data. This is much simpler to guarantee if the settings can not be changed via config.

We still track argon2 settings for local user passwords, but in this case we can more easily cache the hash output after initial argon2 operations so recurring logins are not expensive. It is harder to cache decrypted data in the same way.