### PR TITLE
Retry unavailable db and keycloak at startup

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -6844,3 +6844,87 @@ func TestAuthChallenge(t *testing.T) {
 		t.Fatalf("unexpected challenge string, want '%s', have: '%s'", expectedChallenge, challenge)
 	}
 }
+
+func TestRetryWithBackoff(t *testing.T) {
+	errAllFailed := errors.New("all failed")
+
+	logger := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Caller().Logger()
+
+	tests := []struct {
+		description string
+		sleepBase   time.Duration
+		sleepCap    time.Duration
+		attempts    int
+		operation   func(context.Context) error
+		err         error
+		cancel      bool
+	}{
+		{
+			description: "successful first attempt",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func(context.Context) error {
+				return nil
+			},
+			err:    nil,
+			cancel: false,
+		},
+		{
+			description: "all attempts failed",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func(context.Context) error {
+				return errAllFailed
+			},
+			err:    errAllFailed,
+			cancel: false,
+		},
+		{
+			description: "success after retry",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func() func(context.Context) error {
+				attemptCounter := 0
+				return func(context.Context) error {
+					logger.Info().Int("attempt_counter", attemptCounter).Msg("trying attempt")
+					if attemptCounter > 0 {
+						return nil
+					}
+					attemptCounter++
+					return errors.New("first attempt")
+				}
+			}(),
+			err:    nil,
+			cancel: false,
+		},
+		{
+			description: "failed with cancelled context",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func(context.Context) error {
+				return errors.New("we expect to exit early due to context being cancelled")
+			},
+			err:    context.Canceled,
+			cancel: true,
+		},
+	}
+
+	for _, test := range tests {
+		func() {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if test.cancel {
+				cancel()
+			}
+			err := retryWithBackoff(ctx, logger, test.sleepBase, test.sleepCap, test.attempts, test.description, test.operation)
+			if !errors.Is(err, test.err) {
+				t.Fatalf("wanted err to be: %#v, got: %#v", test.err, err)
+			}
+		}()
+	}
+}


### PR DESCRIPTION
I found the manager stopped with the following error:
```
"setting up OIDC provider failed: 502 Bad Gateway: "
```

This was due to the manager machine restarting at the same time as the
keycloak server. Add some basic retry logic so we are more likely to
recover from simultanous restarts of needed services.

While here do the same for pinging the database. This was not a
problem this time but it seems likely it could be.