### PR TITLE
Default to SameSite=Lax in session cookie

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -8866,6 +8866,7 @@ func getSessionStore(ctx context.Context, logger zerolog.Logger, dbPool *pgxpool
 		Path:     "/",
 		Secure:   true,
 		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
 	}
 
 	return sessionStore, nil


### PR DESCRIPTION
The session defaults to SameSite=None, we can probably be a bit more strict than that.