### PR TITLE
Improve consistency of auth checks in console

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1139,12 +1139,12 @@ func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 		if !ad.Superuser {
 			if ad.OrgName == nil {
 				logger.Error().Msg("consoleCreateDomainHandler: not member of org")
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 				return
 			}
 			if *ad.OrgName != orgIdent.name {
 				logger.Error().Msg("consoleCreateDomainHandler: not member of correct org")
-				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 				return
 			}
 		}
@@ -1272,6 +1272,19 @@ func consoleCreateServiceHandler(dbc *dbConn, cookieStore *sessions.CookieStore)
 			logger.Err(err).Msg("consoleCreateServiceHandler: db request for looking up orgName failed")
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
+		}
+
+		if !ad.Superuser {
+			if ad.OrgName == nil {
+				logger.Error().Msg("consoleCreateServiceHandler: not member of org")
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
+			if *ad.OrgName != orgIdent.name {
+				logger.Error().Msg("consoleCreateServiceHandler: not member of correct org")
+				http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
+				return
+			}
 		}
 
 		switch r.Method {


### PR DESCRIPTION
Add superuser/org membership check to consoleCreateServiceHandler() so it is not possible to display a form to create services for another org which would just be confusing since you do not have permission to submit it anyway.

This is now in sync with how e.g. consoleCreateDomainHandler() does it and while here also update that one to return a 403 Forbidden rather than 500 Internal Server Error when the auth data is not valid.