### PR TITLE
Fix new gosec warnings from upgraded gosec

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3907,7 +3907,7 @@ func sendHTTPReq(client *http.Client, method string, url string, headers map[str
 		req.URL.RawQuery = queryParams.Encode()
 	}
 
-	resp, err := client.Do(req)
+	resp, err := client.Do(req) // #nosec G704 -- Currently only called by keycloakClientManager which uses URL from config, not user input, so not susceptible to SSRF
 	if err != nil {
 		return nil, err
 	}
@@ -4042,7 +4042,7 @@ func (kccm *keycloakClientManager) deleteClientCred(clientID string, registratio
 	}
 	req.Header.Set("Authorization", "Bearer "+registrationAccessToken)
 
-	resp, err := kccm.deleteClient.Do(req)
+	resp, err := kccm.deleteClient.Do(req) // #nosec G704 -- The URL comes from server config, not user input, so not susceptible to SSRF
 	if err != nil {
 		return fmt.Errorf("deleteClientCred: unable to do DELETE request: %w", err)
 	}
@@ -9021,7 +9021,7 @@ func fetchKeyCloakOpenIDConfig(ctx context.Context, client *http.Client, issuer 
 		return openidConfig{}, fmt.Errorf("unable to create GET req for OpenID config: %w", err)
 	}
 
-	confResp, err := client.Do(req)
+	confResp, err := client.Do(req) // #nosec G704 -- The URL comes from server config, not user input, so not susceptible to SSRF
 	if err != nil {
 		return openidConfig{}, fmt.Errorf("unable to GET OpenID config: %w", err)
 	}


### PR DESCRIPTION
It detects potential for SSRF now (user controlled requests) but they all come from server configuration at this point so just ignore them.

Report from gosec:
```
[.../server.go:9024] - G704 (CWE): SSRF via taint analysis (Confidence: HIGH, Severity: HIGH)
    9023:
  > 9024: 	confResp, err := client.Do(req)
    9025: 	if err != nil {

Autofix:

[.../server.go:4045] - G704 (CWE): SSRF via taint analysis (Confidence: HIGH, Severity: HIGH)
    4044:
  > 4045: 	resp, err := kccm.deleteClient.Do(req)
    4046: 	if err != nil {

Autofix:

[.../server.go:3910] - G704 (CWE): SSRF via taint analysis (Confidence: HIGH, Severity: HIGH)
    3909:
  > 3910: 	resp, err := client.Do(req)
    3911: 	if err != nil {

Autofix:
```