### PR TITLE
Fix golangci-lint issues

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -119,6 +119,9 @@ const (
 	// Some default auth providers
 	localAuthProvider    = "local"
 	keycloakAuthProvider = "keycloak"
+
+	// Limit console form posting to 1 MiB
+	formMaxSize = 1024 * 1024
 )
 
 var (
@@ -845,6 +848,21 @@ func consoleAPITokenDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore
 	}
 }
 
+func parseLimitedForm(w http.ResponseWriter, r *http.Request, maxSize int64) error {
+	// G120: Parsing form data without limiting request body size can allow memory exhaustion (use http.MaxBytesReader) (gosec)
+	r.Body = http.MaxBytesReader(w, r.Body, maxSize)
+	err := r.ParseForm()
+	if err != nil {
+		var mbe *http.MaxBytesError
+		if errors.As(err, &mbe) {
+			http.Error(w, http.StatusText(http.StatusRequestEntityTooLarge), http.StatusRequestEntityTooLarge)
+		} else {
+			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		}
+	}
+	return err
+}
+
 func consoleCreateAPITokenHandler(dbc *dbConn, cookieStore *sessions.CookieStore, clientCredAEAD cipher.AEAD, kccm *keycloakClientManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
@@ -899,10 +917,8 @@ func consoleCreateAPITokenHandler(dbc *dbConn, cookieStore *sessions.CookieStore
 				return
 			}
 		case http.MethodPost:
-			err := r.ParseForm()
-			if err != nil {
+			if err := parseLimitedForm(w, r, formMaxSize); err != nil {
 				logger.Err(err).Msg("unable to parse create-api-token POST form")
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}
 
@@ -1198,10 +1214,8 @@ func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 				return
 			}
 		case http.MethodPost:
-			err := r.ParseForm()
-			if err != nil {
+			if err := parseLimitedForm(w, r, formMaxSize); err != nil {
 				logger.Err(err).Msg("unable to parse create-domain POST form")
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}
 
@@ -1336,10 +1350,8 @@ func consoleCreateServiceHandler(dbc *dbConn, cookieStore *sessions.CookieStore)
 				return
 			}
 		case http.MethodPost:
-			err := r.ParseForm()
-			if err != nil {
+			if err := parseLimitedForm(w, r, formMaxSize); err != nil {
 				logger.Err(err).Msg("unable to parse create-service POST form")
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}
 
@@ -1858,10 +1870,8 @@ func consoleCreateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.Cooki
 				return
 			}
 		case http.MethodPost:
-			err := r.ParseForm()
-			if err != nil {
+			if err := parseLimitedForm(w, r, formMaxSize); err != nil {
 				logger.Err(err).Msg("unable to parse create-service-version POST form")
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}
 
@@ -2019,10 +2029,8 @@ func consoleActivateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.Coo
 				return
 			}
 		case http.MethodPost:
-			err := r.ParseForm()
-			if err != nil {
+			if err := parseLimitedForm(w, r, formMaxSize); err != nil {
 				logger.Err(err).Msg("unable to parse activate-service-version POST form")
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}
 
@@ -2185,16 +2193,14 @@ func loginHandler(dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[st
 				return
 			}
 		case http.MethodPost:
-			err := r.ParseForm()
-			if err != nil {
+			if err := parseLimitedForm(w, r, formMaxSize); err != nil {
 				logger.Err(err).Msg("unable to parse login POST form")
-				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
 				return
 			}
 
 			formData := loginForm{}
 
-			err = schemaDecoder.Decode(&formData, r.PostForm)
+			err := schemaDecoder.Decode(&formData, r.PostForm)
 			if err != nil {
 				logger.Err(err).Msg("unable to decode POST form data")
 				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
@@ -9181,11 +9187,11 @@ func newDBConn(dbPool *pgxpool.Pool, queryTimeout time.Duration) (*dbConn, error
 // give such functions a chance to complete the database requests instead of
 // instantly getting cancelled in case the server is told to shut down.
 func (dbc *dbConn) detachedContext(parent context.Context) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(parent), dbc.queryTimeout)
+	return context.WithTimeout(context.WithoutCancel(parent), dbc.queryTimeout) // #nosec G118 -- caller is responsible for cancelling the context
 }
 
 func (dbc *dbConn) detachedContextWithDuration(parent context.Context, timeout time.Duration) (context.Context, context.CancelFunc) {
-	return context.WithTimeout(context.WithoutCancel(parent), timeout)
+	return context.WithTimeout(context.WithoutCancel(parent), timeout) // #nosec G118 -- caller is responsible for cancelling the context
 }
 
 func retryWithBackoff(ctx context.Context, logger zerolog.Logger, sleepBase time.Duration, sleepCap time.Duration, attempts int, description string, operation func(context.Context) error) error {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2410,10 +2410,11 @@ func createKeycloakContainer(ctx context.Context, t *testing.T) (*oidc.Provider,
 		t.Fatalf("unable to fetch openid-configuration: %v", err)
 	}
 
-	jwkCtx, jwkCancel := context.WithCancel(t.Context())
+	jwkCtx, jwkCancel := context.WithCancel(t.Context()) // #nosec G118 -- caller is responsible for cancelling the context
 
 	jwkCache, err := setupJwkCache(jwkCtx, logger, client, oiConf)
 	if err != nil {
+		jwkCancel()
 		t.Fatalf("unable to setup JWK cache: %s", err)
 	}
 
@@ -7044,7 +7045,7 @@ func TestConsoleServicesComponent(t *testing.T) {
 			}
 
 			seenServices := []string{}
-			doc.Find("main #contents table tbody tr").Each(func(i int, s *goquery.Selection) {
+			doc.Find("main #contents table tbody tr").Each(func(_ int, s *goquery.Selection) {
 				var foundAddrs []netip.Addr
 				name := strings.TrimSpace(s.Find("td.name").Text())
 				seenServices = append(seenServices, name)
@@ -7090,6 +7091,66 @@ func TestConsoleServicesComponent(t *testing.T) {
 				if !serviceFound {
 					t.Fatalf("%s: unable to find a service with name '%s'", test.description, serviceName)
 				}
+			}
+		})
+	}
+}
+
+func TestConsoleFormLimit(t *testing.T) {
+	ts, dbPool, err := prepareServer(t, testServerInput{})
+	if dbPool != nil {
+		defer dbPool.Close()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer ts.Close()
+	tests := []struct {
+		description string
+		username    string
+		password    string
+		statusCode  int
+	}{
+		{
+			description: "failed request with too large password field",
+			username:    "admin",
+			password:    strings.Repeat("A", formMaxSize*2),
+			statusCode:  http.StatusRequestEntityTooLarge,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			jar, err := cookiejar.New(nil)
+			if err != nil {
+				t.Fatal(test.description, err)
+			}
+
+			client := &http.Client{Jar: jar}
+
+			form := url.Values{
+				"username": {test.username},
+				"password": {test.password},
+			}
+
+			req, err := http.NewRequest("POST", ts.URL+"/auth/login", strings.NewReader(form.Encode()))
+			if err != nil {
+				t.Fatal(test.description, err)
+			}
+
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			// Needed to make CSRF-validation happy
+			req.Header.Set("Sec-Fetch-Site", "same-origin")
+
+			loginResp, err := client.Do(req)
+			if err != nil {
+				t.Fatal(test.description, err)
+			}
+			defer loginResp.Body.Close()
+
+			if loginResp.StatusCode != test.statusCode {
+				t.Fatalf("%s: unexpected console login status code: %d, expected %d", test.description, loginResp.StatusCode, test.statusCode)
 			}
 		})
 	}


### PR DESCRIPTION
Output before fix:
```
golangci-lint run
pkg/server/server.go:902:22: G120: Parsing form data without limiting request body size can allow memory exhaustion (use http.MaxBytesReader) (gosec)
			err := r.ParseForm()
			                  ^
pkg/server/server.go:1201:22: G120: Parsing form data without limiting request body size can allow memory exhaustion (use http.MaxBytesReader) (gosec)
			err := r.ParseForm()
			                  ^
pkg/server/server.go:2188:22: G120: Parsing form data without limiting request body size can allow memory exhaustion (use http.MaxBytesReader) (gosec)
			err := r.ParseForm()
			                  ^
pkg/server/server.go:9184:28: G118: context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (gosec)
	return context.WithTimeout(context.WithoutCancel(parent), dbc.queryTimeout)
	                          ^
pkg/server/server.go:9188:28: G118: context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (gosec)
	return context.WithTimeout(context.WithoutCancel(parent), timeout)
	                          ^
pkg/server/server_test.go:2413:41: G118: context cancellation function returned by WithCancel/WithTimeout/WithDeadline is not called (gosec)
	jwkCtx, jwkCancel := context.WithCancel(t.Context())
	                                       ^
pkg/server/server_test.go:7047:56: unused-parameter: parameter 'i' seems to be unused, consider removing or renaming it as _ (revive)
			doc.Find("main #contents table tbody tr").Each(func(i int, s *goquery.Selection) {
```

Also add test that checks one of the form POST handlers (login) returns a 413 status as expected for a too large form field.