### PR TITLE
Run "go fix ./..."

### DIFF
--- a/pkg/cdntypes/cdntypes.go
+++ b/pkg/cdntypes/cdntypes.go
@@ -178,7 +178,7 @@ func NewVclStepKeys() VclStepKeys {
 	vclSK := VclStepKeys{
 		FieldToKey: map[string]string{},
 	}
-	for _, field := range reflect.VisibleFields(reflect.TypeOf(VclSteps{})) {
+	for _, field := range reflect.VisibleFields(reflect.TypeFor[VclSteps]()) {
 		vclSK.FieldOrder = append(vclSK.FieldOrder, field.Name)
 		vclSK.FieldToKey[field.Name] = camelCaseToSnakeCase(field.Name)
 	}
@@ -201,7 +201,7 @@ func VclStepsToMap(vclSteps VclSteps) (map[string]string, []string) {
 	for _, field := range reflect.VisibleFields(structVal.Type()) {
 		if _, ok := vclSK.FieldToKey[field.Name]; ok {
 			fieldVal := structVal.FieldByIndex(field.Index)
-			if fieldVal.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.String {
+			if fieldVal.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.String {
 				if !fieldVal.IsNil() && fieldVal.Elem().String() != "" {
 					vclKeyToConf[vclSK.FieldToKey[field.Name]] = fieldVal.Elem().String()
 					keyOrder = append(keyOrder, vclSK.FieldToKey[field.Name])
@@ -312,17 +312,13 @@ type VclStepKeys struct {
 	FieldToKey map[string]string
 }
 
-func Ptr[T any](v T) *T {
-	return &v
-}
-
 type DomainString string
 
 func (ds DomainString) Schema(_ huma.Registry) *huma.Schema {
 	return &huma.Schema{
 		Type:      "string",
-		MinLength: Ptr(1),
-		MaxLength: Ptr(253),
+		MinLength: new(1),
+		MaxLength: new(253),
 	}
 }
 

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -18,11 +18,11 @@ type gooseLogger struct {
 	logger zerolog.Logger
 }
 
-func (gl gooseLogger) Fatalf(format string, v ...interface{}) {
+func (gl gooseLogger) Fatalf(format string, v ...any) {
 	gl.logger.Fatal().Msgf(format, v...)
 }
 
-func (gl gooseLogger) Printf(format string, v ...interface{}) {
+func (gl gooseLogger) Printf(format string, v ...any) {
 	gl.logger.Info().Msgf(format, v...)
 }
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1898,7 +1898,7 @@ func consoleCreateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.Cooki
 			for _, field := range reflect.VisibleFields(structVal.Type()) {
 				if _, ok := vclSK.FieldToKey[field.Name]; ok {
 					fieldVal := structVal.FieldByIndex(field.Index)
-					if fieldVal.Kind() == reflect.Ptr && field.Type.Elem().Kind() == reflect.String {
+					if fieldVal.Kind() == reflect.Pointer && field.Type.Elem().Kind() == reflect.String {
 						if !fieldVal.IsNil() && fieldVal.Elem().String() == "" {
 							fieldVal.Set(reflect.Zero(field.Type))
 						}
@@ -8740,7 +8740,7 @@ func generatePassword(length int) (string, error) {
 	maxBigInt := big.NewInt(int64(len(chars)))
 
 	var b strings.Builder
-	for i := 0; i < length; i++ {
+	for range length {
 		bigI, err := rand.Int(rand.Reader, maxBigInt)
 		if err != nil {
 			return "", fmt.Errorf("rand.Int failed: %w", err)

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -17,6 +17,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -52,10 +53,6 @@ const (
 )
 
 var pgt *postgrestest.Server
-
-func Ptr[T any](v T) *T {
-	return &v
-}
 
 func TestMain(m *testing.M) {
 	ctx := context.Background()
@@ -686,7 +683,7 @@ func TestSessionKeyHandlingNoEnc(t *testing.T) {
 
 	// Try inserting additional session keys with nil encryptionKey
 	numAdded := 2
-	for i := 0; i < numAdded; i++ {
+	for range numAdded {
 		gorillaAuthKey, err := generateRandomKey(32)
 		if err != nil {
 			t.Fatal(err)
@@ -752,7 +749,7 @@ func TestSessionKeyHandlingWithEnc(t *testing.T) {
 
 	// Try inserting additional session keys with nil encryptionKey
 	numAdded := 2
-	for i := 0; i < numAdded; i++ {
+	for range numAdded {
 		gorillaAuthKey, err := generateRandomKey(32)
 		if err != nil {
 			t.Fatal(err)
@@ -7063,13 +7060,7 @@ func TestConsoleServicesComponent(t *testing.T) {
 				// Verify the expected addresses are found
 				if expectedAddrs, ok := test.serviceIPs[name]; ok {
 					for _, expectedAddr := range expectedAddrs {
-						addressPresent := false
-						for _, foundAddr := range foundAddrs {
-							if expectedAddr == foundAddr {
-								addressPresent = true
-								break
-							}
-						}
+						addressPresent := slices.Contains(foundAddrs, expectedAddr)
 						if !addressPresent {
 							t.Fatalf("%s: service '%s' missing expected address %s", test.description, name, expectedAddr)
 						}
@@ -7081,13 +7072,7 @@ func TestConsoleServicesComponent(t *testing.T) {
 			// present, it is OK if there are more that we do not
 			// inspect.
 			for serviceName := range test.serviceIPs {
-				serviceFound := false
-				for _, foundService := range seenServices {
-					if serviceName == foundService {
-						serviceFound = true
-						break
-					}
-				}
+				serviceFound := slices.Contains(seenServices, serviceName)
 				if !serviceFound {
 					t.Fatalf("%s: unable to find a service with name '%s'", test.description, serviceName)
 				}


### PR DESCRIPTION
Reworked in 1.26: https://go.dev/blog/gofix

Also cleanup no longer used Ptr() function, now that "go fix" replaced its use with new().