### PR TITLE
Make entity naming use consistent example/pattern

### DIFF
--- a/pkg/cdntypes/cdntypes.go
+++ b/pkg/cdntypes/cdntypes.go
@@ -28,7 +28,7 @@ type AuthData struct {
 // Types that can be shared across the other packages
 type Org struct {
 	ID               pgtype.UUID `json:"id" doc:"ID of organization, UUIDv4"`
-	Name             string      `json:"name" example:"organization 1" doc:"name of organization"`
+	Name             string      `json:"name" example:"my-org" doc:"name of organization"`
 	ServiceQuota     int64       `json:"service_quota" example:"1" doc:"maximum number of services allowed"`
 	DomainQuota      int64       `json:"domain_quota" example:"5" doc:"maximum number of domains allowed"`
 	ClientTokenQuota int64       `json:"client_token_quota" example:"10" doc:"maximum number of client tokens allowed"`
@@ -78,7 +78,7 @@ type OrgClientRegistrationTokenReEncryptResult struct {
 
 type Service struct {
 	ID            pgtype.UUID `json:"id" doc:"ID of service"`
-	Name          string      `json:"name" example:"service 1" doc:"name of service"`
+	Name          string      `json:"name" example:"my-service" doc:"name of service"`
 	OrgID         pgtype.UUID `json:"org_id" doc:"ID of related organization"`
 	OrgName       string      `json:"org_name" doc:"Name of related organization"`
 	UIDRangeFirst int64       `json:"uid_range_first" doc:"First process UID allocated to this service" db:"uid_range_first"`

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7696,7 +7696,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 			func(ctx context.Context, input *struct {
 				Org  string `path:"org" example:"1" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
 				Body struct {
-					Name        string `json:"name" example:"Some-name" doc:"Name for the token, must be a valid DNS label" minLength:"1" maxLength:"63"`
+					Name        string `json:"name" example:"my-token" doc:"Name for the token, must be a valid DNS label" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
 					Description string `json:"description" example:"Some description" doc:"Description for the token" minLength:"1" maxLength:"100"`
 				}
 			},
@@ -7869,7 +7869,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 			func(ctx context.Context, input *struct {
 				Org  string `query:"org" example:"1" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
 				Body struct {
-					Name string `json:"name" example:"Some name" doc:"Organization name" minLength:"1" maxLength:"253" pattern:"^[a-z]([-.a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS name"`
+					Name string `json:"name" example:"example.com" doc:"Domain name" minLength:"1" maxLength:"253" pattern:"^[a-z]([-.a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS name"`
 				}
 			},
 			) (*orgDomainOutput, error) {
@@ -8130,8 +8130,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 			},
 			func(ctx context.Context, input *struct {
 				Body struct {
-					Name string `json:"name" example:"Some name" doc:"Service name" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
-					Org  string `json:"org" example:"org1" doc:"Name or ID of organization" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
+					Name string `json:"name" example:"my-service" doc:"Service name" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
+					Org  string `json:"org" example:"my-org" doc:"Name or ID of organization" minLength:"1" maxLength:"63"`
 				}
 			},
 			) (*serviceOutput, error) {
@@ -8375,7 +8375,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 				Service string `path:"service" doc:"Service name or ID" minLength:"1" maxLength:"63"`
 				Org     string `query:"org" example:"1" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
 				Body    struct {
-					Name string `json:"name" example:"myname" doc:"name of origin group" minLength:"1" maxLength:"63"`
+					Name string `json:"name" example:"my-origin-group" doc:"name of origin group" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
 				}
 			},
 			) (*originGroupOutput, error) {
@@ -8829,7 +8829,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 			},
 			func(ctx context.Context, input *struct {
 				Body struct {
-					Name        string `json:"name" example:"myname" doc:"name of node group" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
+					Name        string `json:"name" example:"my-node-group" doc:"name of node group" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
 					Description string `json:"description" doc:"some identifying info for the node group" minLength:"1" maxLength:"100" `
 				}
 			},
@@ -9053,7 +9053,7 @@ type user struct {
 type userBodyInput struct {
 	Name string  `json:"name" example:"you@example.com" doc:"The username" minLength:"1" maxLength:"63"`
 	Role string  `json:"role" example:"customer" doc:"Role ID or name" minLength:"1" maxLength:"63"`
-	Org  *string `json:"org,omitempty" example:"Some name" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
+	Org  *string `json:"org,omitempty" example:"my-org" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
 }
 
 type userPostInput struct {
@@ -9106,7 +9106,7 @@ func (ip *IPAddress) UnmarshalJSON(data []byte) error {
 }
 
 type NodeInput struct {
-	Name        string      `json:"name" example:"Some name" doc:"Node name" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
+	Name        string      `json:"name" example:"my-node" doc:"Node name" minLength:"1" maxLength:"63" pattern:"^[a-z]([-a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS label"`
 	Description string      `json:"description" doc:"some identifying info for the node" minLength:"1" maxLength:"100" `
 	Addresses   []IPAddress `json:"addresses,omitempty" doc:"The IPv4 and IPv6 addresses of the node"`
 	Maintenance *bool       `json:"maintenance,omitempty" doc:"If the node should start in maintenance mode or not, defaults to maintenance mode"`

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -2660,6 +2660,75 @@ func TestPostDeleteOrgClientCredentials(t *testing.T) {
 	}
 }
 
+func TestPostOrgClientCredentialsInvalidName(t *testing.T) {
+	ts, dbPool, err := prepareServer(t, testServerInput{})
+	if dbPool != nil {
+		defer dbPool.Close()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ts.Close()
+
+	tests := []struct {
+		description    string
+		username       string
+		password       string
+		expectedStatus int
+		credName       string
+		orgNameOrID    string
+	}{
+		{
+			description:    "failed superuser request with invalid DNS label name",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			credName:       "INVALID NAME",
+			orgNameOrID:    "org1",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			newCred := struct {
+				Name        string `json:"name"`
+				Description string `json:"description"`
+			}{
+				Name:        test.credName,
+				Description: "a description",
+			}
+
+			b, err := json.Marshal(newCred)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			r := bytes.NewReader(b)
+
+			req, err := http.NewRequest("POST", ts.URL+"/api/v1/orgs/"+test.orgNameOrID+"/client-credentials", r)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			req.SetBasicAuth(test.username, test.password)
+
+			resp, err := http.DefaultClient.Do(req) // #nosec G704 -- filled in by test, so not susceptible to SSRF
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if resp.StatusCode != test.expectedStatus {
+				body, err := io.ReadAll(resp.Body)
+				if err != nil {
+					t.Fatal(err)
+				}
+				t.Fatalf("POST org client credentials unexpected status code: %d (%s)", resp.StatusCode, string(body))
+			}
+		})
+	}
+}
+
 func createCred(t *testing.T, testDesc string, ts *httptest.Server, username, password, org string, name string, desc string) cdntypes.NewOrgClientCredential {
 	t.Helper()
 
@@ -3768,6 +3837,14 @@ func TestPostServices(t *testing.T) {
 			expectedStatus: http.StatusCreated,
 			newService:     strings.Repeat("a", 63),
 			org:            "org1",
+		},
+		{
+			description:    "successful superuser request with org UUID",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusCreated,
+			newService:     "new-admin-service-by-uuid",
+			org:            "00000002-0000-0000-0000-000000000001",
 		},
 		{
 			description:    "failed superuser request with org as invalid DNS label",
@@ -5006,6 +5083,15 @@ func TestPostOriginGroups(t *testing.T) {
 			serviceNameOrID: "00000003-0000-0000-0000-000000000001",
 			name:            "origin-group-new2",
 			expectedStatus:  http.StatusCreated,
+		},
+		{
+			description:     "failed superuser request with invalid DNS label name",
+			username:        "admin",
+			password:        validAdminPassword,
+			orgNameOrID:     "00000002-0000-0000-0000-000000000001",
+			serviceNameOrID: "00000003-0000-0000-0000-000000000001",
+			name:            "INVALID NAME",
+			expectedStatus:  http.StatusUnprocessableEntity,
 		},
 	}
 


### PR DESCRIPTION
Fields used for referencing existing entities can be either name or UUID where validation must be less strict, but for input used to actually set the name we want to always make sure the name is a DNS label.

Also update tests to check for validation error and relaxed org name reference in service POST handler.