### PR TITLE
Rename user name to display_name and switch to UUID-only identification

### DIFF
--- a/pkg/cdntypes/cdntypes.go
+++ b/pkg/cdntypes/cdntypes.go
@@ -365,7 +365,7 @@ type Role struct {
 
 type UserListItem struct {
 	ID           pgtype.UUID `json:"id"`
-	Name         string      `json:"name"`
+	DisplayName  string      `json:"display_name"`
 	RoleName     string      `json:"role_name"`
 	OrgName      *string     `json:"org_name"`
 	AuthProvider string      `json:"auth_provider"`
@@ -375,7 +375,7 @@ type UserListItem struct {
 // base user fields with resolved names and auth provider info.
 type UserEditData struct {
 	ID           pgtype.UUID
-	Name         string
+	DisplayName  string
 	RoleName     string
 	OrgName      *string
 	AuthProvider string // "local" or "keycloak"

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -120,7 +120,7 @@ type NodeGroupFormData struct {
 }
 
 type UserFormFields struct {
-	Name            string `schema:"name" validate:"required,min=1,max=63"`
+	DisplayName     string `schema:"display_name" validate:"required,min=1,max=63"`
 	Role            string `schema:"role" validate:"required"`
 	Org             string `schema:"org"`
 	Password        string `schema:"password"`         // #nosec G117 -- Used for form password input, never used for serialized output
@@ -128,7 +128,7 @@ type UserFormFields struct {
 }
 
 type UserFormErrors struct {
-	Name            string
+	DisplayName     string
 	Role            string
 	Org             string
 	Password        string // #nosec G117 -- Error message for password field, not a secret
@@ -244,13 +244,13 @@ var createSlugToSection = func() map[string]string {
 // buildBreadcrumbs returns the ancestor navigation path for the given console
 // URL. Each item is a link. The current page is not included since it is
 // already shown in the <h1> title.
-func buildBreadcrumbs(u *url.URL, orgName string) []Breadcrumb {
+func buildBreadcrumbs(u *url.URL, orgName string, itemLabel string) []Breadcrumb {
 	urlPath := u.EscapedPath()
 	parts := strings.Split(strings.Trim(urlPath, "/"), "/")
 
 	// Handle superuser paths: /console/superuser/{section}[/{item}[/edit]]
 	if strings.HasPrefix(urlPath, "/console/superuser/") {
-		return buildSuperuserBreadcrumbs(parts)
+		return buildSuperuserBreadcrumbs(parts, itemLabel)
 	}
 
 	// Handle superuser create paths: /console/superuser/create/{slug}
@@ -312,7 +312,7 @@ func buildBreadcrumbs(u *url.URL, orgName string) []Breadcrumb {
 // List pages (e.g. /console/superuser/cache-nodes) get no breadcrumbs since
 // they are already the top-level view. Deeper pages (create, edit, and other
 // actions like maintenance/node-group) get the section list page as root crumb.
-func buildSuperuserBreadcrumbs(parts []string) []Breadcrumb {
+func buildSuperuserBreadcrumbs(parts []string, itemLabel string) []Breadcrumb {
 	// parts: ["console", "superuser", ...]
 	if len(parts) <= 3 {
 		// /console/superuser or /console/superuser/{section} — no breadcrumbs
@@ -342,8 +342,12 @@ func buildSuperuserBreadcrumbs(parts []string) []Breadcrumb {
 		if len(parts) >= 5 {
 			// /console/superuser/{section}/{item}/{action} — link to edit
 			// page since there is no standalone item detail page
-			itemName := parts[3]
-			crumbs = append(crumbs, Breadcrumb{Label: itemName, URL: fmt.Sprintf("%s/%s/%s/edit", superBase, sectionPath, itemName)})
+			itemID := parts[3]
+			label := itemID
+			if itemLabel != "" {
+				label = itemLabel
+			}
+			crumbs = append(crumbs, Breadcrumb{Label: label, URL: fmt.Sprintf("%s/%s/%s/edit", superBase, sectionPath, itemID)})
 		}
 
 		return crumbs

--- a/pkg/components/console.templ
+++ b/pkg/components/console.templ
@@ -18,7 +18,7 @@ func activeAttr(section string, u *url.URL) templ.Attributes {
 	return templ.Attributes{}
 }
 
-templ ConsolePage(u *url.URL, title string, ad cdntypes.AuthData, orgName string, availableOrgNames []string, contents templ.Component) {
+templ ConsolePage(u *url.URL, title string, ad cdntypes.AuthData, orgName string, availableOrgNames []string, contents templ.Component, itemLabel string) {
 	<!DOCTYPE html>
 	<html lang="en">
 		@consoleHeadComponent(title)
@@ -41,7 +41,7 @@ templ ConsolePage(u *url.URL, title string, ad cdntypes.AuthData, orgName string
 				</header>
 				@NavBar(u, ad, orgName, availableOrgNames)
 				<main>
-					@breadcrumbNav(buildBreadcrumbs(u, orgName))
+					@breadcrumbNav(buildBreadcrumbs(u, orgName, itemLabel))
 					<h1>{ title } <span id="spinner" class="htmx-indicator spinner"></span></h1>
 					<div id="contents">
 						@contents
@@ -1370,7 +1370,7 @@ templ UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorM
 		<table>
 			<thead>
 				<tr>
-					<th>Name</th>
+					<th>Display name</th>
 					<th>Role</th>
 					<th>Organization</th>
 					<th>Auth Provider</th>
@@ -1380,7 +1380,7 @@ templ UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorM
 			<tbody>
 				for _, user := range users {
 					<tr>
-						<td>{ user.Name }</td>
+						<td>{ user.DisplayName }</td>
 						<td>{ user.RoleName }</td>
 						<td>
 							if user.OrgName != nil {
@@ -1391,12 +1391,12 @@ templ UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorM
 						</td>
 						<td>{ user.AuthProvider }</td>
 						<td>
-							<a href={ templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", user.Name)) } role="button" class="secondary">Edit</a>
+							<a href={ templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", user.ID.String())) } role="button" class="secondary">Edit</a>
 							<button
 								type="button"
-								hx-delete={ string(templ.URL(fmt.Sprintf("/console/superuser/users/%s", user.Name))) }
+								hx-delete={ string(templ.URL(fmt.Sprintf("/console/superuser/users/%s", user.ID.String()))) }
 								hx-target="body"
-								hx-confirm={ fmt.Sprintf("Are you sure you want to delete user '%s'?", user.Name) }
+								hx-confirm={ fmt.Sprintf("Are you sure you want to delete user '%s'?", user.DisplayName) }
 								hx-disabled-elt="this"
 							>
 								Delete
@@ -1417,11 +1417,11 @@ templ CreateUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdn
 		<span class="error-text" role="alert" aria-live="polite">{ formData.Errors.ServerError }</span>
 	}
 	<form method="post" action="/console/superuser/create/user" hx-disabled-elt="find button[type='submit']">
-		<label for="name">
-			Name
-			<input type="text" id="name" name="name" placeholder="Enter username..." value={ formData.Name } required/>
+		<label for="display_name">
+			Display name
+			<input type="text" id="display_name" name="display_name" placeholder="Enter display name..." value={ formData.DisplayName } required/>
 		</label>
-		<span class="error-text">{ formData.Errors.Name }</span>
+		<span class="error-text">{ formData.Errors.DisplayName }</span>
 		<label for="role">
 			Role
 			<select id="role" name="role" required>
@@ -1455,20 +1455,20 @@ templ CreateUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdn
 	</form>
 }
 
-templ EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntypes.Org, authProvider string, userName string, passwordResetData PasswordResetFormData) {
+templ EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntypes.Org, authProvider string, userID string, passwordResetData PasswordResetFormData) {
 	if formData.Errors.ServerError != "" {
 		<span class="error-text" role="alert" aria-live="polite">{ formData.Errors.ServerError }</span>
 	}
-	<form method="post" action={ templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", userName)) } hx-disabled-elt="find button[type='submit']">
-		<label for="name">
-			Name
+	<form method="post" action={ templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", userID)) } hx-disabled-elt="find button[type='submit']">
+		<label for="display_name">
+			Display name
 			if authProvider != cdntypes.LocalAuthProvider {
-				<input type="text" id="name" name="name" value={ formData.Name } readonly/>
+				<input type="text" id="display_name" name="display_name" value={ formData.DisplayName } readonly/>
 			} else {
-				<input type="text" id="name" name="name" placeholder="Enter username..." value={ formData.Name } required/>
+				<input type="text" id="display_name" name="display_name" placeholder="Enter display name..." value={ formData.DisplayName } required/>
 			}
 		</label>
-		<span class="error-text">{ formData.Errors.Name }</span>
+		<span class="error-text">{ formData.Errors.DisplayName }</span>
 		<label for="role">
 			Role
 			<select id="role" name="role" required>
@@ -1500,7 +1500,7 @@ templ EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdnty
 		if passwordResetData.Errors.ServerError != "" {
 			<span class="error-text" role="alert" aria-live="polite">{ passwordResetData.Errors.ServerError }</span>
 		}
-		<form method="post" action={ templ.URL(fmt.Sprintf("/console/superuser/users/%s/reset-password", userName)) } hx-disabled-elt="find button[type='submit']">
+		<form method="post" action={ templ.URL(fmt.Sprintf("/console/superuser/users/%s/reset-password", userID)) } hx-disabled-elt="find button[type='submit']">
 			<label for="password">
 				New password
 				<input type="password" id="password" name="password" placeholder="Enter new password (min 15 characters)..." required/>

--- a/pkg/components/console_templ.go
+++ b/pkg/components/console_templ.go
@@ -26,7 +26,7 @@ func activeAttr(section string, u *url.URL) templ.Attributes {
 	return templ.Attributes{}
 }
 
-func ConsolePage(u *url.URL, title string, ad cdntypes.AuthData, orgName string, availableOrgNames []string, contents templ.Component) templ.Component {
+func ConsolePage(u *url.URL, title string, ad cdntypes.AuthData, orgName string, availableOrgNames []string, contents templ.Component, itemLabel string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -100,7 +100,7 @@ func ConsolePage(u *url.URL, title string, ad cdntypes.AuthData, orgName string,
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = breadcrumbNav(buildBreadcrumbs(u, orgName)).Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = breadcrumbNav(buildBreadcrumbs(u, orgName, itemLabel)).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -5188,7 +5188,7 @@ func UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorMe
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 441, "<table><thead><tr><th>Name</th><th>Role</th><th>Organization</th><th>Auth Provider</th><th>Actions</th></tr></thead> <tbody>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 441, "<table><thead><tr><th>Display name</th><th>Role</th><th>Organization</th><th>Auth Provider</th><th>Actions</th></tr></thead> <tbody>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -5198,9 +5198,9 @@ func UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorMe
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var269 string
-				templ_7745c5c3_Var269, templ_7745c5c3_Err = templ.JoinStringErrs(user.Name)
+				templ_7745c5c3_Var269, templ_7745c5c3_Err = templ.JoinStringErrs(user.DisplayName)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1383, Col: 21}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1383, Col: 28}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var269))
 				if templ_7745c5c3_Err != nil {
@@ -5257,9 +5257,9 @@ func UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorMe
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var273 templ.SafeURL
-				templ_7745c5c3_Var273, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", user.Name)))
+				templ_7745c5c3_Var273, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", user.ID.String())))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1394, Col: 86}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1394, Col: 93}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var273))
 				if templ_7745c5c3_Err != nil {
@@ -5270,9 +5270,9 @@ func UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorMe
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var274 string
-				templ_7745c5c3_Var274, templ_7745c5c3_Err = templ.JoinStringErrs(string(templ.URL(fmt.Sprintf("/console/superuser/users/%s", user.Name))))
+				templ_7745c5c3_Var274, templ_7745c5c3_Err = templ.JoinStringErrs(string(templ.URL(fmt.Sprintf("/console/superuser/users/%s", user.ID.String()))))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1397, Col: 92}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1397, Col: 99}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var274))
 				if templ_7745c5c3_Err != nil {
@@ -5283,9 +5283,9 @@ func UsersContent(users []cdntypes.UserListItem, flashMessages []string, errorMe
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var275 string
-				templ_7745c5c3_Var275, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Are you sure you want to delete user '%s'?", user.Name))
+				templ_7745c5c3_Var275, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Are you sure you want to delete user '%s'?", user.DisplayName))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1399, Col: 89}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1399, Col: 96}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var275))
 				if templ_7745c5c3_Err != nil {
@@ -5345,14 +5345,14 @@ func CreateUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdnt
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 454, "<form method=\"post\" action=\"/console/superuser/create/user\" hx-disabled-elt=\"find button[type='submit']\"><label for=\"name\">Name <input type=\"text\" id=\"name\" name=\"name\" placeholder=\"Enter username...\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 454, "<form method=\"post\" action=\"/console/superuser/create/user\" hx-disabled-elt=\"find button[type='submit']\"><label for=\"display_name\">Display name <input type=\"text\" id=\"display_name\" name=\"display_name\" placeholder=\"Enter display name...\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var278 string
-		templ_7745c5c3_Var278, templ_7745c5c3_Err = templ.JoinStringErrs(formData.Name)
+		templ_7745c5c3_Var278, templ_7745c5c3_Err = templ.JoinStringErrs(formData.DisplayName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1422, Col: 97}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1422, Col: 124}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var278))
 		if templ_7745c5c3_Err != nil {
@@ -5363,9 +5363,9 @@ func CreateUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdnt
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var279 string
-		templ_7745c5c3_Var279, templ_7745c5c3_Err = templ.JoinStringErrs(formData.Errors.Name)
+		templ_7745c5c3_Var279, templ_7745c5c3_Err = templ.JoinStringErrs(formData.Errors.DisplayName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1424, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1424, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var279))
 		if templ_7745c5c3_Err != nil {
@@ -5559,7 +5559,7 @@ func CreateUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdnt
 	})
 }
 
-func EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntypes.Org, authProvider string, userName string, passwordResetData PasswordResetFormData) templ.Component {
+func EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntypes.Org, authProvider string, userID string, passwordResetData PasswordResetFormData) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -5604,27 +5604,27 @@ func EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntyp
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var292 templ.SafeURL
-		templ_7745c5c3_Var292, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", userName)))
+		templ_7745c5c3_Var292, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(fmt.Sprintf("/console/superuser/users/%s/edit", userID)))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1462, Col: 98}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1462, Col: 96}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var292))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 480, "\" hx-disabled-elt=\"find button[type='submit']\"><label for=\"name\">Name ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 480, "\" hx-disabled-elt=\"find button[type='submit']\"><label for=\"display_name\">Display name ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if authProvider != cdntypes.LocalAuthProvider {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 481, "<input type=\"text\" id=\"name\" name=\"name\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 481, "<input type=\"text\" id=\"display_name\" name=\"display_name\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var293 string
-			templ_7745c5c3_Var293, templ_7745c5c3_Err = templ.JoinStringErrs(formData.Name)
+			templ_7745c5c3_Var293, templ_7745c5c3_Err = templ.JoinStringErrs(formData.DisplayName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1466, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1466, Col: 89}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var293))
 			if templ_7745c5c3_Err != nil {
@@ -5635,14 +5635,14 @@ func EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntyp
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 483, "<input type=\"text\" id=\"name\" name=\"name\" placeholder=\"Enter username...\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 483, "<input type=\"text\" id=\"display_name\" name=\"display_name\" placeholder=\"Enter display name...\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var294 string
-			templ_7745c5c3_Var294, templ_7745c5c3_Err = templ.JoinStringErrs(formData.Name)
+			templ_7745c5c3_Var294, templ_7745c5c3_Err = templ.JoinStringErrs(formData.DisplayName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1468, Col: 98}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1468, Col: 125}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var294))
 			if templ_7745c5c3_Err != nil {
@@ -5658,9 +5658,9 @@ func EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntyp
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var295 string
-		templ_7745c5c3_Var295, templ_7745c5c3_Err = templ.JoinStringErrs(formData.Errors.Name)
+		templ_7745c5c3_Var295, templ_7745c5c3_Err = templ.JoinStringErrs(formData.Errors.DisplayName)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1471, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1471, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var295))
 		if templ_7745c5c3_Err != nil {
@@ -5866,9 +5866,9 @@ func EditUserContent(formData UserFormData, roles []cdntypes.Role, orgs []cdntyp
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var306 templ.SafeURL
-			templ_7745c5c3_Var306, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(fmt.Sprintf("/console/superuser/users/%s/reset-password", userName)))
+			templ_7745c5c3_Var306, templ_7745c5c3_Err = templ.JoinURLErrs(templ.URL(fmt.Sprintf("/console/superuser/users/%s/reset-password", userID)))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1503, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 1503, Col: 107}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var306))
 			if templ_7745c5c3_Err != nil {

--- a/pkg/migrations/files/00005_rename_user_name_to_display_name.sql
+++ b/pkg/migrations/files/00005_rename_user_name_to_display_name.sql
@@ -1,0 +1,3 @@
+-- +goose up
+ALTER TABLE users RENAME COLUMN name TO display_name;
+ALTER TABLE users RENAME CONSTRAINT non_empty_name TO non_empty_display_name;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -140,6 +140,7 @@ const (
 	consoleOrgNotFound               = "Organization not found"
 	consoleNodeGroupNotFound         = "Node group not found"
 	consoleUsersTitle                = "Users"
+	consoleEditUserTitleFmt          = "Edit user: %s"
 	consoleUserNotFound              = "The specified user was not found."
 	consoleNotAllowedDeleteSelf      = "You cannot delete your own account."
 	consolePasswordLocalOnly         = "Password management is only available for local users."
@@ -2443,7 +2444,7 @@ func consoleActivateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.Coo
 	}
 }
 
-func renderConsolePage(ctx context.Context, dbc *dbConn, w http.ResponseWriter, r *http.Request, ad cdntypes.AuthData, title string, orgName string, contents templ.Component) error {
+func renderConsolePage(ctx context.Context, dbc *dbConn, w http.ResponseWriter, r *http.Request, ad cdntypes.AuthData, title string, orgName string, contents templ.Component, itemLabel ...string) error {
 	availableOrgNames := []string{}
 	if !ad.Superuser {
 		// The orgName can be empty for users that are not belonging to
@@ -2462,7 +2463,11 @@ func renderConsolePage(ctx context.Context, dbc *dbConn, w http.ResponseWriter, 
 		}
 	}
 
-	component := components.ConsolePage(r.URL, title, ad, orgName, availableOrgNames, contents)
+	label := ""
+	if len(itemLabel) > 0 {
+		label = itemLabel[0]
+	}
+	component := components.ConsolePage(r.URL, title, ad, orgName, availableOrgNames, contents, label)
 	return component.Render(r.Context(), w)
 }
 
@@ -2921,7 +2926,7 @@ func oauth2CallbackHandler(oauth2HTTPClient *http.Client, cookieStore *sessions.
 
 type keycloakClaims struct {
 	// The length checks needs to be kept in sync with the CHECK constraint
-	// for the users.name column in the database.
+	// for the users.display_name column in the database.
 	PreferredUsername string `json:"preferred_username" validate:"min=1,max=63"`
 }
 
@@ -2929,7 +2934,7 @@ func addKeycloakUser(ctx context.Context, dbc *dbConn, subject, name string) (pg
 	var userID, keycloakProviderID pgtype.UUID
 
 	err := pgx.BeginFunc(ctx, dbc.dbPool, func(tx pgx.Tx) error {
-		err := tx.QueryRow(ctx, "INSERT INTO users (name, role_id, auth_provider_id) VALUES ($1, (SELECT id from roles WHERE name=$2), (SELECT id FROM auth_providers WHERE name=$3)) RETURNING id", name, userRole, keycloakAuthProvider).Scan(&userID)
+		err := tx.QueryRow(ctx, "INSERT INTO users (display_name, role_id, auth_provider_id) VALUES ($1, (SELECT id from roles WHERE name=$2), (SELECT id FROM auth_providers WHERE name=$3)) RETURNING id", name, userRole, keycloakAuthProvider).Scan(&userID)
 		if err != nil {
 			var pgErr *pgconn.PgError
 			if errors.As(err, &pgErr) {
@@ -2968,13 +2973,13 @@ func keycloakUser(ctx context.Context, dbc *dbConn, logger *zerolog.Logger, subj
 	dbCtx, cancel := dbc.detachedContext(ctx)
 	defer cancel()
 
-	var username string
+	var displayName string
 	var userID, keycloakProviderID pgtype.UUID
 	err := dbc.dbPool.QueryRow(
 		dbCtx,
-		"SELECT users.id, users.name FROM users JOIN auth_provider_keycloak ON users.id = auth_provider_keycloak.user_id WHERE auth_provider_keycloak.subject = $1",
+		"SELECT users.id, users.display_name FROM users JOIN auth_provider_keycloak ON users.id = auth_provider_keycloak.user_id WHERE auth_provider_keycloak.subject = $1",
 		subject,
-	).Scan(&userID, &username)
+	).Scan(&userID, &displayName)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
 			// User does not exist, add to database
@@ -2982,21 +2987,21 @@ func keycloakUser(ctx context.Context, dbc *dbConn, logger *zerolog.Logger, subj
 			if err != nil {
 				return cdntypes.AuthData{}, fmt.Errorf("unable to add keycloak user '%s' to database: %w", kcc.PreferredUsername, err)
 			}
-			username = kcc.PreferredUsername
+			displayName = kcc.PreferredUsername
 			logger.Info().Str("user_id", userID.String()).Str("keycloak_provider_id", keycloakProviderID.String()).Msg("created user based on keycloak credentials")
 		} else {
 			return cdntypes.AuthData{}, fmt.Errorf("keycloak user lookup failed: %w", err)
 		}
 	}
 
-	if username != kcc.PreferredUsername {
-		logger.Info().Str("from", username).Str("to", kcc.PreferredUsername).Msg("keycloak username out of sync, updating local username")
-		_, err := dbc.dbPool.Exec(dbCtx, "UPDATE users SET name=$1 WHERE id=$2", kcc.PreferredUsername, userID)
+	if displayName != kcc.PreferredUsername {
+		logger.Info().Str("old_display_name", displayName).Str("new_display_name", kcc.PreferredUsername).Msg("keycloak display name out of sync, updating local display name")
+		_, err := dbc.dbPool.Exec(dbCtx, "UPDATE users SET display_name=$1 WHERE id=$2", kcc.PreferredUsername, userID)
 		if err != nil {
 			return cdntypes.AuthData{}, fmt.Errorf("renaming user based on keycloak data failed: %w", err)
 		}
 
-		username = kcc.PreferredUsername
+		displayName = kcc.PreferredUsername
 	}
 
 	var roleID pgtype.UUID
@@ -3016,8 +3021,8 @@ func keycloakUser(ctx context.Context, dbc *dbConn, logger *zerolog.Logger, subj
 		FROM users
 		JOIN roles ON users.role_id = roles.id
 		LEFT JOIN orgs ON users.org_id = orgs.id
-		WHERE users.name=$1`,
-		username,
+		WHERE users.id=$1`,
+		userID,
 	).Scan(
 		&userID,
 		&orgID,
@@ -3031,7 +3036,7 @@ func keycloakUser(ctx context.Context, dbc *dbConn, logger *zerolog.Logger, subj
 	}
 
 	return cdntypes.AuthData{
-		Username:  &username,
+		Username:  &displayName,
 		UserID:    &userID,
 		OrgID:     orgID,
 		OrgName:   orgName,
@@ -3175,7 +3180,7 @@ func dbUserLogin(ctx context.Context, tx pgx.Tx, logger *zerolog.Logger, argon2M
 		JOIN user_argon2keys ON users.id = user_argon2keys.user_id
 		JOIN roles ON users.role_id = roles.id
 		LEFT JOIN orgs ON users.org_id = orgs.id
-		WHERE users.name=$1`,
+		WHERE users.display_name=$1`,
 		username,
 	).Scan(
 		&userID,
@@ -3368,13 +3373,13 @@ func selectUsers(ctx context.Context, dbPool *pgxpool.Pool, logger *zerolog.Logg
 	var rows pgx.Rows
 	var err error
 	if ad.Superuser {
-		rows, err = dbPool.Query(ctx, "SELECT id, name, org_id, role_id FROM users ORDER BY name")
+		rows, err = dbPool.Query(ctx, "SELECT id, display_name, org_id, role_id FROM users ORDER BY display_name")
 		if err != nil {
 			logger.Err(err).Msg("unable to query for users")
 			return nil, fmt.Errorf("unable to query for users")
 		}
 	} else if ad.OrgID != nil && ad.UserID != nil {
-		rows, err = dbPool.Query(ctx, "SELECT id, name, org_id, role_id FROM users WHERE users.id=$1 ORDER BY name", *ad.UserID)
+		rows, err = dbPool.Query(ctx, "SELECT id, display_name, org_id, role_id FROM users WHERE users.id=$1 ORDER BY display_name", *ad.UserID)
 		if err != nil {
 			return nil, fmt.Errorf("unable to query for users for organization: %w", err)
 		}
@@ -3391,37 +3396,21 @@ func selectUsers(ctx context.Context, dbPool *pgxpool.Pool, logger *zerolog.Logg
 	return users, nil
 }
 
-func selectUser(ctx context.Context, dbPool *pgxpool.Pool, userNameOrID string, ad cdntypes.AuthData) (user, error) {
+func selectUser(ctx context.Context, dbPool *pgxpool.Pool, userID pgtype.UUID, ad cdntypes.AuthData) (user, error) {
 	u := user{}
-
-	err := pgx.BeginFunc(ctx, dbPool, func(tx pgx.Tx) error {
-		userIdent, err := newUserIdentifier(ctx, tx, userNameOrID)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return cdnerrors.ErrNotFound
-			}
-			return fmt.Errorf("selectUser: unable to look up user identifier: %w", err)
-		}
-
-		if !ad.Superuser && ad.UserID == nil {
-			return cdnerrors.ErrNotFound
-		}
-
-		if !ad.Superuser && *ad.UserID != userIdent.id {
-			return cdnerrors.ErrNotFound
-		}
-
-		u.ID = userIdent.id
-		u.Name = userIdent.name
-		u.RoleID = userIdent.roleID
-		u.OrgID = userIdent.orgID
-
-		return nil
-	})
-	if err != nil {
-		return user{}, fmt.Errorf("selectUser transaction failed: %w", err)
+	if !ad.Superuser && ad.UserID == nil {
+		return user{}, cdnerrors.ErrNotFound
 	}
-
+	if !ad.Superuser && *ad.UserID != userID {
+		return user{}, cdnerrors.ErrNotFound
+	}
+	err := dbPool.QueryRow(ctx, "SELECT id, display_name, org_id, role_id FROM users WHERE id = $1", userID).Scan(&u.ID, &u.DisplayName, &u.OrgID, &u.RoleID)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return user{}, cdnerrors.ErrNotFound
+		}
+		return user{}, fmt.Errorf("selectUser: query failed: %w", err)
+	}
 	return u, nil
 }
 
@@ -3517,7 +3506,7 @@ func saltFromHex(hexString string) ([]byte, error) {
 	return salt, nil
 }
 
-func setLocalPassword(ctx context.Context, logger *zerolog.Logger, ad cdntypes.AuthData, dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[string, struct{}], userNameOrID string, oldPassword string, newPassword string) (pgtype.UUID, error) {
+func setLocalPassword(ctx context.Context, logger *zerolog.Logger, ad cdntypes.AuthData, dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[string, struct{}], userID pgtype.UUID, oldPassword string, newPassword string) (pgtype.UUID, error) {
 	// While we could potentially do the argon2 operation inside the
 	// transaction below after we know the user is actually allowed to
 	// change the password it feels wrong to keep a transaction open
@@ -3535,26 +3524,27 @@ func setLocalPassword(ctx context.Context, logger *zerolog.Logger, ad cdntypes.A
 
 	var keyID pgtype.UUID
 	err = pgx.BeginFunc(dbCtx, dbc.dbPool, func(tx pgx.Tx) error {
-		userIdent, err := newUserIdentifier(dbCtx, tx, userNameOrID)
+		var displayName string
+		err := tx.QueryRow(dbCtx, "SELECT display_name FROM users WHERE id = $1 FOR SHARE", userID).Scan(&displayName)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return cdnerrors.ErrNotFound
 			}
-			return fmt.Errorf("setLocalPassword: unable to look up user identifier: %w", err)
+			return fmt.Errorf("setLocalPassword: unable to look up user: %w", err)
 		}
 
 		// We only allow the setting of passwords for users using the "local" auth provider
 		var authProviderName string
-		err = tx.QueryRow(dbCtx, "SELECT auth_providers.name FROM auth_providers JOIN users ON auth_providers.id = users.auth_provider_id WHERE users.id=$1 FOR SHARE", userIdent.id).Scan(&authProviderName)
+		err = tx.QueryRow(dbCtx, "SELECT auth_providers.name FROM auth_providers JOIN users ON auth_providers.id = users.auth_provider_id WHERE users.id=$1 FOR SHARE", userID).Scan(&authProviderName)
 		if err != nil {
-			return fmt.Errorf("unable to look up name of auth provider for user with id '%s': %w", userIdent.id, err)
+			return fmt.Errorf("unable to look up name of auth provider for user with id '%s': %w", userID, err)
 		}
 
 		// A superuser can change any password and a normal user can only change their own password
 		if !ad.Superuser && ad.UserID == nil {
 			return cdnerrors.ErrForbidden
 		}
-		if !ad.Superuser && *ad.UserID != userIdent.id {
+		if !ad.Superuser && *ad.UserID != userID {
 			return cdnerrors.ErrForbidden
 		}
 
@@ -3573,14 +3563,14 @@ func setLocalPassword(ctx context.Context, logger *zerolog.Logger, ad cdntypes.A
 		// optimal but not sure about a better way since we want to do
 		// the following upsert operation in the transaction.
 		if !ad.Superuser {
-			_, err := dbUserLogin(dbCtx, tx, logger, argon2Mutex, loginCache, userIdent.name, oldPassword)
+			_, err := dbUserLogin(dbCtx, tx, logger, argon2Mutex, loginCache, displayName, oldPassword)
 			if err != nil {
 				logger.Err(err).Msg("old password check failed")
 				return cdnerrors.ErrBadOldPassword
 			}
 		}
 
-		keyID, err = upsertArgon2Tx(dbCtx, tx, userIdent.id, a2Data)
+		keyID, err = upsertArgon2Tx(dbCtx, tx, userID, a2Data)
 		if err != nil {
 			return fmt.Errorf("unable to UPDATE user argon2 data: %w", err)
 		}
@@ -3915,7 +3905,7 @@ func insertL4LBNodeTx(ctx context.Context, tx pgx.Tx, name string, description s
 	return l4lbNodeID, nil
 }
 
-func createUser(ctx context.Context, dbc *dbConn, name string, role string, org *string, a2Data *argon2Data, ad cdntypes.AuthData) (user, error) {
+func createUser(ctx context.Context, dbc *dbConn, displayName string, role string, org *string, a2Data *argon2Data, ad cdntypes.AuthData) (user, error) {
 	if !ad.Superuser {
 		return user{}, cdnerrors.ErrForbidden
 	}
@@ -3953,7 +3943,7 @@ func createUser(ctx context.Context, dbc *dbConn, name string, role string, org 
 			orgID = &orgIdent.id
 		}
 
-		userID, err = insertUserTx(dbCtx, tx, name, orgID, roleIdent.id, authProviderID)
+		userID, err = insertUserTx(dbCtx, tx, displayName, orgID, roleIdent.id, authProviderID)
 		if err != nil {
 			return fmt.Errorf("createUser: INSERT failed: %w", err)
 		}
@@ -3979,61 +3969,49 @@ func createUser(ctx context.Context, dbc *dbConn, name string, role string, org 
 	}
 
 	return user{
-		ID:     userID,
-		Name:   name,
-		RoleID: roleIdent.id,
-		OrgID:  orgID,
+		ID:          userID,
+		DisplayName: displayName,
+		RoleID:      roleIdent.id,
+		OrgID:       orgID,
 	}, nil
 }
 
-func deleteUser(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, ad cdntypes.AuthData, userNameOrID string) (pgtype.UUID, error) {
+func deleteUser(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, ad cdntypes.AuthData, userID pgtype.UUID) (string, error) {
 	if !ad.Superuser {
-		return pgtype.UUID{}, cdnerrors.ErrForbidden
+		return "", cdnerrors.ErrForbidden
+	}
+	if ad.UserID == nil {
+		return "", cdnerrors.ErrForbidden
+	}
+	if *ad.UserID == userID {
+		return "", cdnerrors.ErrSelfDelete
 	}
 
 	dbCtx, cancel := dbc.detachedContext(ctx)
 	defer cancel()
 
-	var userID pgtype.UUID
+	var displayName string
 	err := pgx.BeginFunc(dbCtx, dbc.dbPool, func(tx pgx.Tx) error {
-		userIdent, err := newUserIdentifier(dbCtx, tx, userNameOrID)
+		err := tx.QueryRow(dbCtx, "DELETE FROM users WHERE id = $1 RETURNING display_name", userID).Scan(&displayName)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return cdnerrors.ErrNotFound
 			}
-			return fmt.Errorf("deleteUser: unable to look up user identifier: %w", err)
-		}
-
-		// Org client credentials (API tokens) have no UserID and
-		// are not allowed to delete users.
-		if ad.UserID == nil {
-			return cdnerrors.ErrForbidden
-		}
-
-		// A user cannot delete itself to protect against locking
-		// yourself out of the system.
-		if *ad.UserID == userIdent.id {
-			return cdnerrors.ErrSelfDelete
-		}
-
-		err = tx.QueryRow(dbCtx, "DELETE FROM users WHERE id = $1 RETURNING id", userIdent.id).Scan(&userID)
-		if err != nil {
 			return fmt.Errorf("unable to DELETE user: %w", err)
 		}
-
 		return nil
 	})
 	if err != nil {
 		logger.Err(err).Msg("deleteUser transaction failed")
-		return pgtype.UUID{}, fmt.Errorf("deleteUser transaction failed: %w", err)
+		return "", fmt.Errorf("deleteUser transaction failed: %w", err)
 	}
 
-	return userID, nil
+	return displayName, nil
 }
 
-func insertUserTx(ctx context.Context, tx pgx.Tx, name string, orgID *pgtype.UUID, roleID pgtype.UUID, authProviderID pgtype.UUID) (pgtype.UUID, error) {
+func insertUserTx(ctx context.Context, tx pgx.Tx, displayName string, orgID *pgtype.UUID, roleID pgtype.UUID, authProviderID pgtype.UUID) (pgtype.UUID, error) {
 	var userID pgtype.UUID
-	err := tx.QueryRow(ctx, "INSERT INTO users (name, org_id, role_id, auth_provider_id) VALUES ($1, $2, $3, $4) RETURNING id", name, orgID, roleID, authProviderID).Scan(&userID)
+	err := tx.QueryRow(ctx, "INSERT INTO users (display_name, org_id, role_id, auth_provider_id) VALUES ($1, $2, $3, $4) RETURNING id", displayName, orgID, roleID, authProviderID).Scan(&userID)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
@@ -4065,8 +4043,8 @@ func authProviderNameToIDTx(ctx context.Context, tx pgx.Tx, name string) (pgtype
 	return authProviderID, nil
 }
 
-func updateUserTx(ctx context.Context, tx pgx.Tx, userID pgtype.UUID, name string, orgID *pgtype.UUID, roleID pgtype.UUID) error {
-	_, err := tx.Exec(ctx, "UPDATE users SET name = $1, org_id = $2, role_id = $3 WHERE id = $4", name, orgID, roleID, userID)
+func updateUserTx(ctx context.Context, tx pgx.Tx, userID pgtype.UUID, displayName string, orgID *pgtype.UUID, roleID pgtype.UUID) error {
+	_, err := tx.Exec(ctx, "UPDATE users SET display_name = $1, org_id = $2, role_id = $3 WHERE id = $4", displayName, orgID, roleID, userID)
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
@@ -4083,7 +4061,7 @@ func updateUserTx(ctx context.Context, tx pgx.Tx, userID pgtype.UUID, name strin
 	return nil
 }
 
-func updateUser(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, nameOrID string, name string, org *string, role string) (user, error) {
+func updateUser(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, userID pgtype.UUID, displayName string, org *string, role string) (user, error) {
 	if !ad.Superuser {
 		return user{}, cdnerrors.ErrForbidden
 	}
@@ -4093,12 +4071,13 @@ func updateUser(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, nameOrID
 
 	var u user
 	err := pgx.BeginFunc(dbCtx, dbc.dbPool, func(tx pgx.Tx) error {
-		userIdent, err := newUserIdentifier(dbCtx, tx, nameOrID)
+		var currentDisplayName string
+		err := tx.QueryRow(dbCtx, "SELECT display_name FROM users WHERE id = $1 FOR SHARE", userID).Scan(&currentDisplayName)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return cdnerrors.ErrNotFound
 			}
-			return fmt.Errorf("unable to parse user name or ID for PUT: %w", err)
+			return fmt.Errorf("unable to look up user for PUT: %w", err)
 		}
 
 		roleIdent, err := newRoleIdentifier(dbCtx, tx, role)
@@ -4117,13 +4096,13 @@ func updateUser(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, nameOrID
 		}
 
 		// Non-local users (e.g. Keycloak) cannot be renamed — their
-		// name is managed by the identity provider.
-		updateName := name
-		if updateName == "" || updateName == userIdent.name {
-			updateName = userIdent.name
+		// display name is managed by the identity provider.
+		updateDisplayName := displayName
+		if updateDisplayName == "" || updateDisplayName == currentDisplayName {
+			updateDisplayName = currentDisplayName
 		} else {
 			var authProviderName string
-			err = tx.QueryRow(dbCtx, "SELECT auth_providers.name FROM auth_providers JOIN users ON auth_providers.id = users.auth_provider_id WHERE users.id=$1 FOR SHARE", userIdent.id).Scan(&authProviderName)
+			err = tx.QueryRow(dbCtx, "SELECT auth_providers.name FROM auth_providers JOIN users ON auth_providers.id = users.auth_provider_id WHERE users.id=$1 FOR SHARE", userID).Scan(&authProviderName)
 			if err != nil {
 				return fmt.Errorf("updateUser: unable to look up auth provider: %w", err)
 			}
@@ -4132,13 +4111,13 @@ func updateUser(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, nameOrID
 			}
 		}
 
-		err = updateUserTx(dbCtx, tx, userIdent.id, updateName, orgID, roleIdent.id)
+		err = updateUserTx(dbCtx, tx, userID, updateDisplayName, orgID, roleIdent.id)
 		if err != nil {
 			return fmt.Errorf("update failed: %w", err)
 		}
 
-		u.ID = userIdent.id
-		u.Name = updateName
+		u.ID = userID
+		u.DisplayName = updateDisplayName
 		u.RoleID = roleIdent.id
 		u.OrgID = orgID
 
@@ -4157,13 +4136,13 @@ func selectUserListItems(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData)
 	}
 
 	rows, err := dbc.dbPool.Query(ctx,
-		`SELECT u.id, u.name, r.name AS role_name,
+		`SELECT u.id, u.display_name, r.name AS role_name,
 			o.name AS org_name, ap.name AS auth_provider
 		FROM users u
 		JOIN roles r ON u.role_id = r.id
 		JOIN auth_providers ap ON u.auth_provider_id = ap.id
 		LEFT JOIN orgs o ON u.org_id = o.id
-		ORDER BY u.name`)
+		ORDER BY u.display_name`)
 	if err != nil {
 		return nil, fmt.Errorf("unable to query for user list items: %w", err)
 	}
@@ -4190,45 +4169,27 @@ func selectRoles(ctx context.Context, dbc *dbConn) ([]cdntypes.Role, error) {
 	return roles, nil
 }
 
-func selectUserForEdit(ctx context.Context, dbc *dbConn, userNameOrID string, ad cdntypes.AuthData) (cdntypes.UserEditData, error) {
+func selectUserForEdit(ctx context.Context, dbc *dbConn, userID pgtype.UUID, ad cdntypes.AuthData) (cdntypes.UserEditData, error) {
 	if !ad.Superuser {
 		return cdntypes.UserEditData{}, cdnerrors.ErrForbidden
 	}
 
 	var userData cdntypes.UserEditData
-	err := pgx.BeginFunc(ctx, dbc.dbPool, func(tx pgx.Tx) error {
-		userIdent, err := newUserIdentifier(ctx, tx, userNameOrID)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return cdnerrors.ErrNotFound
-			}
-			return fmt.Errorf("selectUserForEdit: unable to parse user identifier: %w", err)
-		}
-
-		err = tx.QueryRow(ctx,
-			`SELECT u.id, u.name, r.name AS role_name,
-				o.name AS org_name, ap.name AS auth_provider
-			FROM users u
-			JOIN roles r ON u.role_id = r.id
-			JOIN auth_providers ap ON u.auth_provider_id = ap.id
-			LEFT JOIN orgs o ON u.org_id = o.id
-			WHERE u.id = $1`, userIdent.id).Scan(
-			&userData.ID, &userData.Name, &userData.RoleName,
-			&userData.OrgName, &userData.AuthProvider)
-		if err != nil {
-			if errors.Is(err, pgx.ErrNoRows) {
-				return cdnerrors.ErrNotFound
-			}
-			return fmt.Errorf("selectUserForEdit: query failed: %w", err)
-		}
-
-		return nil
-	})
+	err := dbc.dbPool.QueryRow(ctx,
+		`SELECT u.id, u.display_name, r.name AS role_name,
+			o.name AS org_name, ap.name AS auth_provider
+		FROM users u
+		JOIN roles r ON u.role_id = r.id
+		JOIN auth_providers ap ON u.auth_provider_id = ap.id
+		LEFT JOIN orgs o ON u.org_id = o.id
+		WHERE u.id = $1`, userID).Scan(
+		&userData.ID, &userData.DisplayName, &userData.RoleName,
+		&userData.OrgName, &userData.AuthProvider)
 	if err != nil {
-		if errors.Is(err, cdnerrors.ErrNotFound) {
-			return cdntypes.UserEditData{}, err
+		if errors.Is(err, pgx.ErrNoRows) {
+			return cdntypes.UserEditData{}, cdnerrors.ErrNotFound
 		}
-		return cdntypes.UserEditData{}, fmt.Errorf("selectUserForEdit: transaction failed: %w", err)
+		return cdntypes.UserEditData{}, fmt.Errorf("selectUserForEdit: query failed: %w", err)
 	}
 
 	return userData, nil
@@ -5393,12 +5354,6 @@ type roleIdentifier struct {
 	resourceIdentifier
 }
 
-type userIdentifier struct {
-	resourceIdentifier
-	orgID  *pgtype.UUID
-	roleID pgtype.UUID
-}
-
 type cacheNodeIdentifier struct {
 	resourceIdentifier
 }
@@ -5525,48 +5480,6 @@ func newRoleIdentifier(ctx context.Context, tx pgx.Tx, input string) (roleIdenti
 			name: name,
 			id:   id,
 		},
-	}, nil
-}
-
-func isUUID(input string) bool {
-	inputID := new(pgtype.UUID)
-	err := inputID.Scan(input)
-	return err == nil
-}
-
-func newUserIdentifier(ctx context.Context, tx pgx.Tx, input string) (userIdentifier, error) {
-	if input == "" {
-		return userIdentifier{}, errEmptyInputIdentifier
-	}
-
-	var id pgtype.UUID
-	var orgID *pgtype.UUID
-	var roleID pgtype.UUID
-	var name string
-
-	inputID := new(pgtype.UUID)
-	err := inputID.Scan(input)
-	if err == nil {
-		// This is a valid UUID, treat it as an ID and collect the name (also verifying the id exists in the process)
-		err := tx.QueryRow(ctx, "SELECT id, name, org_id, role_id FROM users WHERE id = $1 FOR SHARE", *inputID).Scan(&id, &name, &orgID, &roleID)
-		if err != nil {
-			return userIdentifier{}, err
-		}
-	} else {
-		// This is not a valid UUID, treat it as a name and validate it by mapping it to an ID (org names are globally unique)
-		err := tx.QueryRow(ctx, "SELECT id, name, org_id, role_id FROM users WHERE name = $1 FOR SHARE", input).Scan(&id, &name, &orgID, &roleID)
-		if err != nil {
-			return userIdentifier{}, err
-		}
-	}
-
-	return userIdentifier{
-		resourceIdentifier: resourceIdentifier{
-			name: name,
-			id:   id,
-		},
-		orgID:  orgID,
-		roleID: roleID,
 	}, nil
 }
 
@@ -7700,12 +7613,12 @@ func newChiRouter(conf config.Config, logger zerolog.Logger, dbc *dbConn, argon2
 		r.Get("/superuser/node-groups/{nodegroup}/edit", consoleEditNodeGroupHandler(dbc, cookieStore))
 		r.Post("/superuser/node-groups/{nodegroup}/edit", consoleEditNodeGroupHandler(dbc, cookieStore))
 		r.Get("/superuser/users", consoleUsersHandler(dbc, cookieStore))
-		r.Delete("/superuser/users/{user}", consoleUserDeleteHandler(dbc, cookieStore))
+		r.Delete("/superuser/users/{userID}", consoleUserDeleteHandler(dbc, cookieStore))
 		r.Get("/superuser/create/user", consoleCreateUserHandler(dbc, cookieStore, argon2Mutex))
 		r.Post("/superuser/create/user", consoleCreateUserHandler(dbc, cookieStore, argon2Mutex))
-		r.Get("/superuser/users/{user}/edit", consoleEditUserHandler(dbc, cookieStore))
-		r.Post("/superuser/users/{user}/edit", consoleEditUserHandler(dbc, cookieStore))
-		r.Post("/superuser/users/{user}/reset-password", consoleUserResetPasswordHandler(dbc, cookieStore, argon2Mutex, loginCache))
+		r.Get("/superuser/users/{userID}/edit", consoleEditUserHandler(dbc, cookieStore))
+		r.Post("/superuser/users/{userID}/edit", consoleEditUserHandler(dbc, cookieStore))
+		r.Post("/superuser/users/{userID}/reset-password", consoleUserResetPasswordHandler(dbc, cookieStore, argon2Mutex, loginCache))
 	})
 
 	oauth2HTTPClient := &http.Client{
@@ -7892,8 +7805,9 @@ func newAPIAuthMiddleware(api huma.API, dbc *dbConn, argon2Mutex *sync.Mutex, lo
 }
 
 const (
-	v1User                  = "/v1/users/{user}"
+	v1User                  = "/v1/users/{userID}"
 	userNotFound            = "user not found"
+	invalidUserIDFormat     = "invalid user ID format"
 	notAllowedToAddResource = "not allowed to add resource"
 )
 
@@ -7968,7 +7882,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 		})
 
 		huma.Get(api, v1User, func(ctx context.Context, input *struct {
-			User string `path:"user" example:"1" doc:"User ID or name" minLength:"1" maxLength:"63"`
+			UserID string `path:"userID" example:"00000006-0000-0000-0000-000000000001" doc:"User ID (UUID)"`
 		},
 		) (*userOutput, error) {
 			logger := zlog.Ctx(ctx)
@@ -7978,7 +7892,13 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 				return nil, errors.New("unable to read auth data from user GET handler")
 			}
 
-			user, err := selectUser(ctx, dbc.dbPool, input.User, ad)
+			var userID pgtype.UUID
+			err := userID.Scan(input.UserID)
+			if err != nil {
+				return nil, huma.Error422UnprocessableEntity(invalidUserIDFormat)
+			}
+
+			user, err := selectUser(ctx, dbc.dbPool, userID, ad)
 			if err != nil {
 				if errors.Is(err, cdnerrors.ErrForbidden) {
 					return nil, huma.Error403Forbidden(api403String)
@@ -7988,10 +7908,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 				logger.Err(err).Msg("unable to query users")
 				return nil, err
 			}
-			resp := &userOutput{}
-			resp.Body.ID = user.ID
-			resp.Body.Name = user.Name
-			return resp, nil
+			return &userOutput{Body: user}, nil
 		})
 
 		// We want to set a custom DefaultStatus, that is why we are not just using huma.Post().
@@ -8013,7 +7930,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 					return nil, errors.New("unable to read auth data from users POST handler")
 				}
 
-				user, err := createUser(ctx, dbc, input.Body.Name, input.Body.Role, input.Body.Org, nil, ad)
+				user, err := createUser(ctx, dbc, input.Body.DisplayName, input.Body.Role, input.Body.Org, nil, ad)
 				if err != nil {
 					switch {
 					case errors.Is(err, cdnerrors.ErrForbidden):
@@ -8035,9 +7952,9 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 			},
 		)
 
-		huma.Put(api, "/v1/users/{user}/local-password", func(ctx context.Context, input *struct {
-			User string `path:"user" example:"1" doc:"User ID or name" minLength:"1" maxLength:"63"`
-			Body struct {
+		huma.Put(api, "/v1/users/{userID}/local-password", func(ctx context.Context, input *struct {
+			UserID string `path:"userID" example:"00000006-0000-0000-0000-000000000001" doc:"User ID (UUID)"`
+			Body   struct {
 				OldPassword string `json:"old,omitempty" example:"verysecretpassword" doc:"The previous local password, not needed if superuser" minLength:"1" maxLength:"64"`
 				NewPassword string `json:"new" example:"verysecretpassword" doc:"The new user password" minLength:"15" maxLength:"64"`
 			}
@@ -8049,7 +7966,13 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 				return nil, errors.New("unable to read auth data from local-password PUT handler")
 			}
 
-			_, err := setLocalPassword(ctx, logger, ad, dbc, argon2Mutex, loginCache, input.User, input.Body.OldPassword, input.Body.NewPassword)
+			var userID pgtype.UUID
+			err := userID.Scan(input.UserID)
+			if err != nil {
+				return nil, huma.Error422UnprocessableEntity(invalidUserIDFormat)
+			}
+
+			_, err = setLocalPassword(ctx, logger, ad, dbc, argon2Mutex, loginCache, userID, input.Body.OldPassword, input.Body.NewPassword)
 			if err != nil {
 				switch {
 				case errors.Is(err, cdnerrors.ErrOldPasswordRequired):
@@ -8077,7 +8000,13 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 				return nil, errors.New("unable to read auth data from user PUT handler")
 			}
 
-			user, err := updateUser(ctx, dbc, ad, input.User, input.Body.Name, input.Body.Org, input.Body.Role)
+			var userID pgtype.UUID
+			err := userID.Scan(input.UserID)
+			if err != nil {
+				return nil, huma.Error422UnprocessableEntity(invalidUserIDFormat)
+			}
+
+			user, err := updateUser(ctx, dbc, ad, userID, input.Body.DisplayName, input.Body.Org, input.Body.Role)
 			if err != nil {
 				switch {
 				case errors.Is(err, cdnerrors.ErrForbidden):
@@ -8101,7 +8030,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 		})
 
 		huma.Delete(api, v1User, func(ctx context.Context, input *struct {
-			User string `path:"user" example:"username" doc:"user ID or name" minLength:"1" maxLength:"63"`
+			UserID string `path:"userID" example:"00000006-0000-0000-0000-000000000001" doc:"User ID (UUID)"`
 		},
 		) (*struct{}, error) {
 			logger := zlog.Ctx(ctx)
@@ -8111,7 +8040,13 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 				return nil, errors.New("unable to read auth data from user DELETE handler")
 			}
 
-			_, err := deleteUser(ctx, logger, dbc, ad, input.User)
+			var userID pgtype.UUID
+			err := userID.Scan(input.UserID)
+			if err != nil {
+				return nil, huma.Error422UnprocessableEntity(invalidUserIDFormat)
+			}
+
+			_, err = deleteUser(ctx, logger, dbc, ad, userID)
 			if err != nil {
 				switch {
 				case errors.Is(err, cdnerrors.ErrSelfDelete):
@@ -9581,17 +9516,22 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 	return nil
 }
 
+// user is the API response type for user entities. Unlike other entities
+// (orgs, services, domains, nodes) where Name is an app-controlled DNS-label
+// identifier, user display names are free-form attributes from external
+// identity providers (e.g. "user@example.com" from OIDC/Keycloak) and are
+// not used for identification — users are always identified by UUID.
 type user struct {
-	ID     pgtype.UUID  `json:"id" doc:"ID of user"`
-	Name   string       `json:"name" example:"user1" doc:"name of user"`
-	RoleID pgtype.UUID  `json:"role_id" doc:"ID of organization, UUIDv4"`
-	OrgID  *pgtype.UUID `json:"org_id" doc:"ID of organization, UUIDv4"`
+	ID          pgtype.UUID  `json:"id" doc:"ID of user"`
+	DisplayName string       `json:"display_name" example:"you@example.com" doc:"display name of user"`
+	RoleID      pgtype.UUID  `json:"role_id" doc:"ID of role, UUIDv4"`
+	OrgID       *pgtype.UUID `json:"org_id" doc:"ID of organization, UUIDv4"`
 }
 
 type userBodyInput struct {
-	Name string  `json:"name" example:"you@example.com" doc:"The username" minLength:"1" maxLength:"63"`
-	Role string  `json:"role" example:"customer" doc:"Role ID or name" minLength:"1" maxLength:"63"`
-	Org  *string `json:"org,omitempty" example:"my-org" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
+	DisplayName string  `json:"display_name" example:"you@example.com" doc:"Display name of the user" minLength:"1" maxLength:"63"`
+	Role        string  `json:"role" example:"customer" doc:"Role ID or name" minLength:"1" maxLength:"63"`
+	Org         *string `json:"org,omitempty" example:"my-org" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
 }
 
 type userPostInput struct {
@@ -9599,8 +9539,8 @@ type userPostInput struct {
 }
 
 type userPutInput struct {
-	User string `path:"user" example:"1" doc:"User ID or name" minLength:"1" maxLength:"63"`
-	Body userBodyInput
+	UserID string `path:"userID" example:"00000006-0000-0000-0000-000000000001" doc:"User ID (UUID)"`
+	Body   userBodyInput
 }
 
 type userOutput struct {
@@ -12395,6 +12335,20 @@ func consoleUsersHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.Ha
 	}
 }
 
+func parseUserIDParam(w http.ResponseWriter, r *http.Request) (pgtype.UUID, bool) {
+	userIDStr := chi.URLParam(r, "userID")
+	if userIDStr == "" {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return pgtype.UUID{}, false
+	}
+	var userID pgtype.UUID
+	if err := userID.Scan(userIDStr); err != nil {
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return pgtype.UUID{}, false
+	}
+	return userID, true
+}
+
 func consoleUserDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
@@ -12405,13 +12359,12 @@ func consoleUserDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) ht
 			return
 		}
 
-		userName := chi.URLParam(r, "user")
-		if userName == "" {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		userID, ok := parseUserIDParam(w, r)
+		if !ok {
 			return
 		}
 
-		_, err := deleteUser(ctx, logger, dbc, ad, userName)
+		displayName, err := deleteUser(ctx, logger, dbc, ad, userID)
 		if err != nil {
 			var errorMessage string
 			switch {
@@ -12442,7 +12395,7 @@ func consoleUserDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) ht
 			return
 		}
 
-		session.AddFlash(fmt.Sprintf("User '%s' deleted!", userName), flashMessageKeys.users)
+		session.AddFlash(fmt.Sprintf("User '%s' deleted!", displayName), flashMessageKeys.users)
 		err = session.Save(r, w)
 		if err != nil {
 			http.Error(w, unableToSetFlashMessage, http.StatusInternalServerError)
@@ -12510,8 +12463,8 @@ func consoleCreateUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore, ar
 				validationErrors := err.(validator.ValidationErrors)
 				for _, fieldError := range validationErrors {
 					switch fieldError.StructField() {
-					case "Name":
-						formData.Errors.Name = fieldError.Error()
+					case "DisplayName":
+						formData.Errors.DisplayName = fieldError.Error()
 					case "Role":
 						formData.Errors.Role = fieldError.Error()
 					}
@@ -12563,13 +12516,13 @@ func consoleCreateUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore, ar
 				return
 			}
 
-			_, err = createUser(ctx, dbc, formFields.Name, formFields.Role, org, &a2Data, ad)
+			_, err = createUser(ctx, dbc, formFields.DisplayName, formFields.Role, org, &a2Data, ad)
 			if err != nil {
 				switch {
 				case errors.Is(err, cdnerrors.ErrAlreadyExists):
-					formData.Errors.Name = consoleAlreadyExists
+					formData.Errors.DisplayName = consoleAlreadyExists
 				case errors.Is(err, cdnerrors.ErrCheckViolation):
-					formData.Errors.Name = "Invalid user name"
+					formData.Errors.DisplayName = "Invalid display name"
 				case errors.Is(err, pgx.ErrNoRows):
 					formData.Errors.ServerError = "Selected role or organization does not exist"
 				default:
@@ -12580,7 +12533,7 @@ func consoleCreateUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore, ar
 				return
 			}
 
-			session.AddFlash(fmt.Sprintf("User '%s' created!", formFields.Name), flashMessageKeys.users)
+			session.AddFlash(fmt.Sprintf("User '%s' created!", formFields.DisplayName), flashMessageKeys.users)
 			err = session.Save(r, w)
 			if err != nil {
 				http.Error(w, unableToSetFlashMessage, http.StatusInternalServerError)
@@ -12606,15 +12559,15 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 			return
 		}
 
-		userName := chi.URLParam(r, "user")
-		if userName == "" {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		userID, ok := parseUserIDParam(w, r)
+		if !ok {
 			return
 		}
 
-		title := fmt.Sprintf("Edit user: %s", userName)
+		errorTitle := fmt.Sprintf(consoleEditUserTitleFmt, userID.String())
 
-		renderEditForm := func(formData components.UserFormData, authProvider string, passwordResetData components.PasswordResetFormData) {
+		renderEditForm := func(displayName string, formData components.UserFormData, authProvider string, passwordResetData components.PasswordResetFormData) {
+			title := fmt.Sprintf(consoleEditUserTitleFmt, displayName)
 			roles, rolesErr := selectRoles(ctx, dbc)
 			if rolesErr != nil {
 				logger.Err(rolesErr).Msg("edit user: unable to fetch roles")
@@ -12627,7 +12580,7 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
-			err := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.EditUserContent(formData, roles, orgs, authProvider, userName, passwordResetData))
+			err := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.EditUserContent(formData, roles, orgs, authProvider, userID.String(), passwordResetData), displayName)
 			if err != nil {
 				logger.Err(err).Msg(consoleEditUserRenderErr)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -12636,12 +12589,12 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 
 		switch r.Method {
 		case http.MethodGet:
-			userData, err := selectUserForEdit(ctx, dbc, userName, ad)
+			userData, err := selectUserForEdit(ctx, dbc, userID, ad)
 			if err != nil {
 				logger.Err(err).Msg("edit user: unable to fetch user")
 				switch {
 				case errors.Is(err, cdnerrors.ErrNotFound):
-					renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
+					renderErr := renderConsolePage(ctx, dbc, w, r, ad, errorTitle, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
 					if renderErr != nil {
 						logger.Err(renderErr).Msg(consoleEditUserRenderErr)
 						http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -12659,23 +12612,23 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 
 			formData := components.UserFormData{
 				UserFormFields: components.UserFormFields{
-					Name: userData.Name,
-					Role: userData.RoleName,
-					Org:  orgName,
+					DisplayName: userData.DisplayName,
+					Role:        userData.RoleName,
+					Org:         orgName,
 				},
 			}
 
-			renderEditForm(formData, userData.AuthProvider, components.PasswordResetFormData{})
+			renderEditForm(userData.DisplayName, formData, userData.AuthProvider, components.PasswordResetFormData{})
 		case http.MethodPost:
 			// Fetch existing user to determine auth provider — needed to
 			// enforce that non-local (e.g. Keycloak) users cannot be renamed
 			// (the form shows a readonly input, but that is only a UI hint).
-			userData, err := selectUserForEdit(ctx, dbc, userName, ad)
+			userData, err := selectUserForEdit(ctx, dbc, userID, ad)
 			if err != nil {
 				logger.Err(err).Msg("edit user POST: unable to fetch user")
 				switch {
 				case errors.Is(err, cdnerrors.ErrNotFound):
-					renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
+					renderErr := renderConsolePage(ctx, dbc, w, r, ad, errorTitle, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
 					if renderErr != nil {
 						logger.Err(renderErr).Msg(consoleEditUserRenderErr)
 						http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -12701,7 +12654,7 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 
 			// Non-local users cannot be renamed — ignore submitted name
 			if userData.AuthProvider != localAuthProvider {
-				formFields.Name = userData.Name
+				formFields.DisplayName = userData.DisplayName
 			}
 
 			formData := components.UserFormData{
@@ -12713,13 +12666,13 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 				validationErrors := err.(validator.ValidationErrors)
 				for _, fieldError := range validationErrors {
 					switch fieldError.StructField() {
-					case "Name":
-						formData.Errors.Name = fieldError.Error()
+					case "DisplayName":
+						formData.Errors.DisplayName = fieldError.Error()
 					case "Role":
 						formData.Errors.Role = fieldError.Error()
 					}
 				}
-				renderEditForm(formData, userData.AuthProvider, components.PasswordResetFormData{})
+				renderEditForm(userData.DisplayName, formData, userData.AuthProvider, components.PasswordResetFormData{})
 				return
 			}
 
@@ -12729,7 +12682,7 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 				org = &formFields.Org
 			}
 
-			_, err = updateUser(ctx, dbc, ad, userName, formFields.Name, org, formFields.Role)
+			_, err = updateUser(ctx, dbc, ad, userID, formFields.DisplayName, org, formFields.Role)
 			if err != nil {
 				logger.Err(err).Msg("user update failed")
 				switch {
@@ -12738,21 +12691,21 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 				case errors.Is(err, cdnerrors.ErrNotFound):
 					formData.Errors.ServerError = consoleUserNotFound
 				case errors.Is(err, cdnerrors.ErrAlreadyExists):
-					formData.Errors.Name = consoleAlreadyExists
+					formData.Errors.DisplayName = consoleAlreadyExists
 				case errors.Is(err, cdnerrors.ErrCheckViolation):
 					formData.Errors.ServerError = "Invalid user data"
 				case errors.Is(err, cdnerrors.ErrNotLocalUser):
-					formData.Errors.Name = "Renaming is only available for local users"
+					formData.Errors.DisplayName = "Renaming is only available for local users"
 				case errors.Is(err, pgx.ErrNoRows):
 					formData.Errors.ServerError = "Selected role or organization does not exist"
 				default:
 					formData.Errors.ServerError = "User update failed"
 				}
-				renderEditForm(formData, userData.AuthProvider, components.PasswordResetFormData{})
+				renderEditForm(userData.DisplayName, formData, userData.AuthProvider, components.PasswordResetFormData{})
 				return
 			}
 
-			session.AddFlash(fmt.Sprintf("User '%s' updated!", formFields.Name), flashMessageKeys.users)
+			session.AddFlash(fmt.Sprintf("User '%s' updated!", formFields.DisplayName), flashMessageKeys.users)
 			err = session.Save(r, w)
 			if err != nil {
 				http.Error(w, unableToSetFlashMessage, http.StatusInternalServerError)
@@ -12783,21 +12736,22 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 			return
 		}
 
-		userName := chi.URLParam(r, "user")
-		if userName == "" {
-			http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		userID, ok := parseUserIDParam(w, r)
+		if !ok {
 			return
 		}
 
-		title := fmt.Sprintf("Edit user: %s", userName)
+		errorTitle := fmt.Sprintf(consoleEditUserTitleFmt, userID.String())
 
 		renderEditWithPasswordError := func(passwordResetData components.PasswordResetFormData) {
-			userData, fetchErr := selectUserForEdit(ctx, dbc, userName, ad)
+			userData, fetchErr := selectUserForEdit(ctx, dbc, userID, ad)
 			if fetchErr != nil {
 				logger.Err(fetchErr).Msg("reset password: unable to fetch user for re-render")
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
+
+			title := fmt.Sprintf(consoleEditUserTitleFmt, userData.DisplayName)
 
 			orgName := ""
 			if userData.OrgName != nil {
@@ -12806,9 +12760,9 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 
 			formData := components.UserFormData{
 				UserFormFields: components.UserFormFields{
-					Name: userData.Name,
-					Role: userData.RoleName,
-					Org:  orgName,
+					DisplayName: userData.DisplayName,
+					Role:        userData.RoleName,
+					Org:         orgName,
 				},
 			}
 
@@ -12824,7 +12778,7 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				return
 			}
-			renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.EditUserContent(formData, roles, orgs, userData.AuthProvider, userName, passwordResetData))
+			renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.EditUserContent(formData, roles, orgs, userData.AuthProvider, userID.String(), passwordResetData), userData.DisplayName)
 			if renderErr != nil {
 				logger.Err(renderErr).Msg(consoleEditUserRenderErr)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -12832,11 +12786,11 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 		}
 
 		// Verify user exists and get auth provider
-		userData, err := selectUserForEdit(ctx, dbc, userName, ad)
+		userData, err := selectUserForEdit(ctx, dbc, userID, ad)
 		if err != nil {
 			logger.Err(err).Msg("reset password: unable to fetch user")
 			if errors.Is(err, cdnerrors.ErrNotFound) {
-				renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
+				renderErr := renderConsolePage(ctx, dbc, w, r, ad, errorTitle, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
 				if renderErr != nil {
 					logger.Err(renderErr).Msg(consoleEditUserRenderErr)
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -12848,7 +12802,7 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 		}
 
 		if userData.AuthProvider != localAuthProvider {
-			renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.ConsoleErrorContent(consolePasswordLocalOnly))
+			renderErr := renderConsolePage(ctx, dbc, w, r, ad, errorTitle, sessionSelectedOrg(session), components.ConsoleErrorContent(consolePasswordLocalOnly))
 			if renderErr != nil {
 				logger.Err(renderErr).Msg(consoleEditUserRenderErr)
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -12896,7 +12850,7 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 			return
 		}
 
-		_, err = setLocalPassword(ctx, logger, ad, dbc, argon2Mutex, loginCache, userName, "", formFields.Password)
+		_, err = setLocalPassword(ctx, logger, ad, dbc, argon2Mutex, loginCache, userID, "", formFields.Password)
 		if err != nil {
 			logger.Err(err).Msg("reset password: unable to set password")
 			switch {
@@ -12904,13 +12858,13 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 				// Race condition: auth provider changed after the check above.
 				// The template won't render the password section for non-local
 				// users, so use ConsoleErrorContent instead.
-				renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.ConsoleErrorContent(consolePasswordLocalOnly))
+				renderErr := renderConsolePage(ctx, dbc, w, r, ad, fmt.Sprintf(consoleEditUserTitleFmt, userData.DisplayName), sessionSelectedOrg(session), components.ConsoleErrorContent(consolePasswordLocalOnly))
 				if renderErr != nil {
 					logger.Err(renderErr).Msg(consoleEditUserRenderErr)
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 				}
 			case errors.Is(err, cdnerrors.ErrNotFound):
-				renderErr := renderConsolePage(ctx, dbc, w, r, ad, title, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
+				renderErr := renderConsolePage(ctx, dbc, w, r, ad, errorTitle, sessionSelectedOrg(session), components.ConsoleErrorContent(consoleUserNotFound))
 				if renderErr != nil {
 					logger.Err(renderErr).Msg(consoleEditUserRenderErr)
 					http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -12925,16 +12879,14 @@ func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 			return
 		}
 
-		session.AddFlash(fmt.Sprintf("Password for user '%s' has been reset!", userName), flashMessageKeys.users)
+		session.AddFlash(fmt.Sprintf("Password for user '%s' has been reset!", userData.DisplayName), flashMessageKeys.users)
 		err = session.Save(r, w)
 		if err != nil {
 			http.Error(w, unableToSetFlashMessage, http.StatusInternalServerError)
 			return
 		}
 
-		// User names are not restricted to DNS labels and may contain characters
-		// that need URL escaping (e.g. '@', spaces, '%').
-		validatedRedirect(fmt.Sprintf("/console/superuser/users/%s/edit", url.PathEscape(userName)), w, r, http.StatusSeeOther)
+		validatedRedirect(fmt.Sprintf("/console/superuser/users/%s/edit", userID.String()), w, r, http.StatusSeeOther)
 	}
 }
 

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -194,17 +194,17 @@ func populateTestData(dbPool *pgxpool.Pool, encryptedSessionKey bool) error {
 
 		// Users
 		// No org, local user
-		"INSERT INTO users (id, role_id, auth_provider_id, name) VALUES ('00000014-0000-0000-0000-000000000001', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000001', 'put-user-1')",
+		"INSERT INTO users (id, role_id, auth_provider_id, display_name) VALUES ('00000014-0000-0000-0000-000000000001', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000001', 'put-user-1')",
 		"INSERT INTO user_argon2keys (id, user_id, key, salt, time, memory, threads, tag_size) VALUES ('00000017-0000-0000-0000-000000000001', '00000014-0000-0000-0000-000000000001', '\\x00', '\\x00', 3, 65536, 4, 32)",
 		// No org, local users, used to test DELETE
-		"INSERT INTO users (id, role_id, auth_provider_id, name) VALUES ('00000014-0000-0000-0000-000000000002', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000001', 'delete-local-user-1')",
+		"INSERT INTO users (id, role_id, auth_provider_id, display_name) VALUES ('00000014-0000-0000-0000-000000000002', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000001', 'delete-local-user-1')",
 		"INSERT INTO user_argon2keys (id, user_id, key, salt, time, memory, threads, tag_size) VALUES ('00000017-0000-0000-0000-000000000002', '00000014-0000-0000-0000-000000000002', '\\x00', '\\x00', 3, 65536, 4, 32)",
-		"INSERT INTO users (id, role_id, auth_provider_id, name) VALUES ('00000014-0000-0000-0000-000000000003', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000001', 'delete-local-user-2')",
+		"INSERT INTO users (id, role_id, auth_provider_id, display_name) VALUES ('00000014-0000-0000-0000-000000000003', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000001', 'delete-local-user-2')",
 		"INSERT INTO user_argon2keys (id, user_id, key, salt, time, memory, threads, tag_size) VALUES ('00000017-0000-0000-0000-000000000003', '00000014-0000-0000-0000-000000000003', '\\x00', '\\x00', 3, 65536, 4, 32)",
 		// No org, keycloak users, used to test DELETE
-		"INSERT INTO users (id, role_id, auth_provider_id, name) VALUES ('00000014-0000-0000-0000-000000000004', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000002', 'delete-keycloak-user-1')",
+		"INSERT INTO users (id, role_id, auth_provider_id, display_name) VALUES ('00000014-0000-0000-0000-000000000004', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000002', 'delete-keycloak-user-1')",
 		"INSERT INTO auth_provider_keycloak (id, user_id, subject) VALUES ('00000018-0000-0000-0000-000000000001', '00000014-0000-0000-0000-000000000004', '00000019-0000-0000-0000-000000000001')",
-		"INSERT INTO users (id, role_id, auth_provider_id, name) VALUES ('00000014-0000-0000-0000-000000000005', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000002', 'delete-keycloak-user-2')",
+		"INSERT INTO users (id, role_id, auth_provider_id, display_name) VALUES ('00000014-0000-0000-0000-000000000005', '00000005-0000-0000-0000-000000000002', '00000010-0000-0000-0000-000000000002', 'delete-keycloak-user-2')",
 		"INSERT INTO auth_provider_keycloak (id, user_id, subject) VALUES ('00000018-0000-0000-0000-000000000002', '00000014-0000-0000-0000-000000000005', '00000019-0000-0000-0000-000000000002')",
 
 		// Node groups
@@ -359,7 +359,7 @@ func populateTestData(dbPool *pgxpool.Pool, encryptedSessionKey bool) error {
 				return err
 			}
 
-			_, err = tx.Exec(ctx, "INSERT INTO users (id, org_id, name, role_id, auth_provider_id) VALUES ($1, $2, $3, (SELECT id FROM roles WHERE name=$4), (SELECT id from auth_providers WHERE name=$5))", userID, orgID, localUser.name, localUser.role, localUser.authProvider)
+			_, err = tx.Exec(ctx, "INSERT INTO users (id, org_id, display_name, role_id, auth_provider_id) VALUES ($1, $2, $3, (SELECT id FROM roles WHERE name=$4), (SELECT id from auth_providers WHERE name=$5))", userID, orgID, localUser.name, localUser.role, localUser.authProvider)
 			if err != nil {
 				return err
 			}
@@ -910,70 +910,56 @@ func TestGetUser(t *testing.T) {
 		description    string
 		username       string
 		password       string
-		nameOrID       string
+		userID         string
 		expectedStatus int
 	}{
 		{
 			description:    "successful superuser request with ID",
 			username:       "admin",
 			password:       validAdminPassword,
-			nameOrID:       "00000006-0000-0000-0000-000000000001",
-			expectedStatus: http.StatusOK,
-		},
-		{
-			description:    "successful superuser request with name",
-			username:       "admin",
-			password:       validAdminPassword,
-			nameOrID:       "username1",
+			userID:         "00000006-0000-0000-0000-000000000001",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			description:    "successful user request for itself with ID",
 			username:       "username1",
 			password:       validUserPassword,
-			nameOrID:       "00000006-0000-0000-0000-000000000002",
-			expectedStatus: http.StatusOK,
-		},
-		{
-			description:    "successful user request for itself with name",
-			username:       "username1",
-			password:       validUserPassword,
-			nameOrID:       "username1",
+			userID:         "00000006-0000-0000-0000-000000000002",
 			expectedStatus: http.StatusOK,
 		},
 		{
 			description:    "failed user request, bad password",
 			username:       "username1",
 			password:       "badpassword1",
-			nameOrID:       "00000006-0000-0000-0000-000000000001",
+			userID:         "00000006-0000-0000-0000-000000000001",
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
 			description:    "failed user request, no password set",
 			username:       "username4-no-pw",
 			password:       "somepassword",
-			nameOrID:       "username4-no-pw",
+			userID:         "00000006-0000-0000-0000-000000000005",
 			expectedStatus: http.StatusUnauthorized,
 		},
 		{
 			description:    "failed lookup of another user with ID",
 			username:       "username2",
 			password:       "password2",
-			nameOrID:       "00000006-0000-0000-0000-000000000001",
+			userID:         "00000006-0000-0000-0000-000000000001",
 			expectedStatus: http.StatusNotFound,
 		},
 		{
-			description:    "failed lookup of another user with name",
-			username:       "username2",
-			password:       "password2",
-			nameOrID:       "username1",
-			expectedStatus: http.StatusNotFound,
+			description:    "failed request with invalid UUID",
+			username:       "admin",
+			password:       validAdminPassword,
+			userID:         "not-a-uuid",
+			expectedStatus: http.StatusUnprocessableEntity,
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			req, err := http.NewRequest("GET", ts.URL+"/api/v1/users/"+test.nameOrID, nil)
+			req, err := http.NewRequest("GET", ts.URL+"/api/v1/users/"+test.userID, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -991,7 +977,7 @@ func TestGetUser(t *testing.T) {
 				if err != nil {
 					t.Fatal(err)
 				}
-				t.Fatalf("GET users/%s unexpected status code: %d (%s)", test.nameOrID, resp.StatusCode, string(r))
+				t.Fatalf("GET users/%s unexpected status code: %d (%s)", test.userID, resp.StatusCode, string(r))
 			}
 
 			jsonData, err := io.ReadAll(resp.Body)
@@ -1100,13 +1086,13 @@ func TestPostUsers(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			newUser := struct {
-				Name string `json:"name"`
-				Role string `json:"role"`
-				Org  string `json:"org,omitempty"`
+				DisplayName string `json:"display_name"`
+				Role        string `json:"role"`
+				Org         string `json:"org,omitempty"`
 			}{
-				Name: test.addedUser,
-				Org:  test.orgIDorName,
-				Role: test.roleIDorName,
+				DisplayName: test.addedUser,
+				Org:         test.orgIDorName,
+				Role:        test.roleIDorName,
 			}
 
 			b, err := json.Marshal(newUser)
@@ -1164,7 +1150,7 @@ func TestPutUser(t *testing.T) {
 		username            string
 		password            string
 		expectedStatus      int
-		targetUserIDorName  string
+		targetUserID        string
 		updatedOrgIDorName  string
 		updatedRoleIDorName string
 		updatedName         string
@@ -1174,37 +1160,37 @@ func TestPutUser(t *testing.T) {
 			username:            "admin",
 			password:            validAdminPassword,
 			expectedStatus:      http.StatusOK,
-			targetUserIDorName:  "00000014-0000-0000-0000-000000000001",
+			targetUserID:        "00000014-0000-0000-0000-000000000001",
 			updatedOrgIDorName:  "00000002-0000-0000-0000-000000000001",
 			updatedRoleIDorName: "00000005-0000-0000-0000-000000000002",
 			updatedName:         "put-user-1",
 		},
 		{
-			description:         "successful superuser request with names",
+			description:         "successful superuser request with names for org and role",
 			username:            "admin",
 			password:            validAdminPassword,
 			expectedStatus:      http.StatusOK,
-			targetUserIDorName:  "put-user-1",
+			targetUserID:        "00000014-0000-0000-0000-000000000001",
 			updatedName:         "put-user-1",
 			updatedOrgIDorName:  "org2",
 			updatedRoleIDorName: "user",
 		},
 		{
-			description:         "successful superuser request with names, null org",
+			description:         "successful superuser request, null org",
 			username:            "admin",
 			password:            validAdminPassword,
 			expectedStatus:      http.StatusOK,
-			targetUserIDorName:  "put-user-1",
+			targetUserID:        "00000014-0000-0000-0000-000000000001",
 			updatedName:         "put-user-1",
 			updatedOrgIDorName:  "",
 			updatedRoleIDorName: "user",
 		},
 		{
-			description:         "failed non-superuser request with names",
+			description:         "failed non-superuser request",
 			username:            "username1",
 			password:            validUserPassword,
 			expectedStatus:      http.StatusForbidden,
-			targetUserIDorName:  "username1",
+			targetUserID:        "00000006-0000-0000-0000-000000000002",
 			updatedName:         "username1",
 			updatedOrgIDorName:  "org1",
 			updatedRoleIDorName: "user",
@@ -1214,9 +1200,19 @@ func TestPutUser(t *testing.T) {
 			username:            "admin",
 			password:            validAdminPassword,
 			expectedStatus:      http.StatusUnprocessableEntity,
-			targetUserIDorName:  "delete-keycloak-user-1",
+			targetUserID:        "00000014-0000-0000-0000-000000000004",
 			updatedName:         "renamed-keycloak-user",
 			updatedOrgIDorName:  "",
+			updatedRoleIDorName: "user",
+		},
+		{
+			description:         "failed request with invalid UUID",
+			username:            "admin",
+			password:            validAdminPassword,
+			expectedStatus:      http.StatusUnprocessableEntity,
+			targetUserID:        "not-a-uuid",
+			updatedName:         "some-user",
+			updatedOrgIDorName:  "org1",
 			updatedRoleIDorName: "user",
 		},
 	}
@@ -1224,13 +1220,13 @@ func TestPutUser(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			putUser := struct {
-				Org  string `json:"org,omitempty"`
-				Role string `json:"role"`
-				Name string `json:"name"`
+				Org         string `json:"org,omitempty"`
+				Role        string `json:"role"`
+				DisplayName string `json:"display_name"`
 			}{
-				Org:  test.updatedOrgIDorName,
-				Role: test.updatedRoleIDorName,
-				Name: test.updatedName,
+				Org:         test.updatedOrgIDorName,
+				Role:        test.updatedRoleIDorName,
+				DisplayName: test.updatedName,
 			}
 
 			b, err := json.Marshal(putUser)
@@ -1242,7 +1238,7 @@ func TestPutUser(t *testing.T) {
 
 			t.Log(string(b))
 
-			req, err := http.NewRequest("PUT", ts.URL+"/api/v1/users/"+test.targetUserIDorName, r)
+			req, err := http.NewRequest("PUT", ts.URL+"/api/v1/users/"+test.targetUserID, r)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1286,82 +1282,83 @@ func TestDeleteUser(t *testing.T) {
 	defer ts.Close()
 
 	tests := []struct {
-		description        string
-		username           string
-		password           string
-		expectedStatus     int
-		targetUserIDorName string
+		description    string
+		username       string
+		password       string
+		expectedStatus int
+		targetUserID   string
 	}{
 		{
-			description:        "successful superuser request with IDs",
-			username:           "admin",
-			password:           validAdminPassword,
-			expectedStatus:     http.StatusNoContent,
-			targetUserIDorName: "00000014-0000-0000-0000-000000000002",
+			description:    "successful superuser request for local user",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusNoContent,
+			targetUserID:   "00000014-0000-0000-0000-000000000002",
 		},
 		{
-			description:        "successful superuser request with name",
-			username:           "admin",
-			password:           validAdminPassword,
-			expectedStatus:     http.StatusNoContent,
-			targetUserIDorName: "delete-local-user-2",
+			description:    "successful superuser request for local user 2",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusNoContent,
+			targetUserID:   "00000014-0000-0000-0000-000000000003",
 		},
 		{
-			description:        "successful superuser request with IDs for keycloak",
-			username:           "admin",
-			password:           validAdminPassword,
-			expectedStatus:     http.StatusNoContent,
-			targetUserIDorName: "00000014-0000-0000-0000-000000000004",
+			description:    "successful superuser request for keycloak user",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusNoContent,
+			targetUserID:   "00000014-0000-0000-0000-000000000004",
 		},
 		{
-			description:        "successful superuser request with name for keycloak",
-			username:           "admin",
-			password:           validAdminPassword,
-			expectedStatus:     http.StatusNoContent,
-			targetUserIDorName: "delete-keycloak-user-2",
+			description:    "successful superuser request for keycloak user 2",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusNoContent,
+			targetUserID:   "00000014-0000-0000-0000-000000000005",
 		},
 		{
-			description:        "failed superuser request trying to remove itself with ID",
-			username:           "admin",
-			password:           validAdminPassword,
-			expectedStatus:     http.StatusForbidden,
-			targetUserIDorName: "00000006-0000-0000-0000-000000000001",
+			description:    "failed superuser request trying to remove itself",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusForbidden,
+			targetUserID:   "00000006-0000-0000-0000-000000000001",
 		},
 		{
-			description:        "failed superuser request trying to remove itself with name",
-			username:           "admin",
-			password:           validAdminPassword,
-			expectedStatus:     http.StatusForbidden,
-			targetUserIDorName: "admin",
+			description:    "failed non-superuser request",
+			username:       "username1",
+			password:       validUserPassword,
+			expectedStatus: http.StatusForbidden,
+			targetUserID:   "00000006-0000-0000-0000-000000000001",
 		},
 		{
-			description:        "failed non-superuser request with name",
-			username:           "username1",
-			password:           validUserPassword,
-			expectedStatus:     http.StatusForbidden,
-			targetUserIDorName: "admin",
+			description:    "failed request with invalid UUID",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			targetUserID:   "not-a-uuid",
 		},
 	}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			ctx := context.Background()
-			// Verify uses exists prior to deletion
-			var testQuery string
-			if isUUID(test.targetUserIDorName) {
-				testQuery = "SELECT name, id FROM users WHERE id = $1"
-			} else {
-				testQuery = "SELECT name, id FROM users WHERE name = $1"
+			testQuery := "SELECT display_name, id FROM users WHERE id = $1"
+
+			// Only verify DB state for valid UUIDs
+			var checkUUID pgtype.UUID
+			validUUID := checkUUID.Scan(test.targetUserID) == nil
+
+			if validUUID {
+				// Verify user exists prior to deletion
+				var displayName string
+				var id pgtype.UUID
+				err := dbPool.QueryRow(ctx, testQuery, test.targetUserID).Scan(&displayName, &id)
+				if err != nil {
+					t.Fatal(err)
+				}
 			}
 
-			var name string
-			var id pgtype.UUID
-			err := dbPool.QueryRow(ctx, testQuery, test.targetUserIDorName).Scan(&name, &id)
-			if err != nil {
-				t.Fatal(err)
-			}
-
-			req, err := http.NewRequest("DELETE", ts.URL+"/api/v1/users/"+test.targetUserIDorName, nil)
+			req, err := http.NewRequest("DELETE", ts.URL+"/api/v1/users/"+test.targetUserID, nil)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1389,19 +1386,23 @@ func TestDeleteUser(t *testing.T) {
 
 			t.Logf("%s\n", jsonData)
 
-			// Verify user is removed if a http.StatusNoContent was returned, otherwise they are expected to still exist
-			err = dbPool.QueryRow(ctx, testQuery, test.targetUserIDorName).Scan(&name, &id)
-			if err == nil {
-				if test.expectedStatus == http.StatusNoContent {
-					// The delete seemed successful, why are they still in the db
-					t.Fatalf("user is not deleted as expected, name: '%s', id: '%s'", name, id)
-				}
-			} else {
-				if !errors.Is(err, pgx.ErrNoRows) {
-					t.Fatalf("user deleted pre-check unexpected error: '%s', id: '%s', %s", name, id, err)
-				}
-				if test.expectedStatus != http.StatusNoContent {
-					t.Fatalf("database returned no rows, but the delete should have been forbidden: '%s', id: '%s', %s", name, id, err)
+			if validUUID {
+				// Verify user is removed if a http.StatusNoContent was returned, otherwise they are expected to still exist
+				var displayName string
+				var id pgtype.UUID
+				err = dbPool.QueryRow(ctx, testQuery, test.targetUserID).Scan(&displayName, &id)
+				if err == nil {
+					if test.expectedStatus == http.StatusNoContent {
+						// The delete seemed successful, why are they still in the db
+						t.Fatalf("user is not deleted as expected, display_name: '%s', id: '%s'", displayName, id)
+					}
+				} else {
+					if !errors.Is(err, pgx.ErrNoRows) {
+						t.Fatalf("user deleted pre-check unexpected error: '%s', id: '%s', %s", displayName, id, err)
+					}
+					if test.expectedStatus != http.StatusNoContent {
+						t.Fatalf("database returned no rows, but the delete should have been forbidden: '%s', id: '%s', %s", displayName, id, err)
+					}
 				}
 			}
 		})
@@ -1419,64 +1420,74 @@ func TestPutPassword(t *testing.T) {
 	defer ts.Close()
 
 	tests := []struct {
-		description          string
-		username             string
-		password             string
-		expectedStatus       int
-		modifiedUserIDorName string
-		oldPassword          string
-		newPassword          string
-		shouldSucceed        bool
+		description    string
+		username       string
+		password       string
+		expectedStatus int
+		modifiedUserID string
+		modifiedUser   string
+		oldPassword    string
+		newPassword    string
 	}{
 		{
-			description:          "successful superuser request with IDs",
-			username:             "admin",
-			password:             validAdminPassword,
-			expectedStatus:       http.StatusNoContent,
-			modifiedUserIDorName: "username4-no-pw",
-			oldPassword:          "",
-			newPassword:          "updated-password-1",
-			shouldSucceed:        true,
+			description:    "successful superuser request with IDs",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusNoContent,
+			modifiedUserID: "00000006-0000-0000-0000-000000000005",
+			modifiedUser:   "username4-no-pw",
+			oldPassword:    "",
+			newPassword:    "updated-password-1",
 		},
 		{
-			description:          "failed request for user missing password",
-			username:             "username4-no-pw",
-			password:             "",
-			expectedStatus:       http.StatusUnauthorized,
-			modifiedUserIDorName: "username5-no-pw",
-			oldPassword:          "",
-			newPassword:          "updated-password-2",
-			shouldSucceed:        false,
+			description:    "failed request for user missing password",
+			username:       "username4-no-pw",
+			password:       "",
+			expectedStatus: http.StatusUnauthorized,
+			modifiedUserID: "00000006-0000-0000-0000-000000000006",
+			modifiedUser:   "username5-no-pw",
+			oldPassword:    "",
+			newPassword:    "updated-password-2",
 		},
 		{
-			description:          "successful request for user changing their own password",
-			username:             "username1",
-			password:             validUserPassword,
-			expectedStatus:       http.StatusNoContent,
-			modifiedUserIDorName: "username1",
-			oldPassword:          validUserPassword,
-			newPassword:          "updated-password-3",
-			shouldSucceed:        true,
+			description:    "successful request for user changing their own password",
+			username:       "username1",
+			password:       validUserPassword,
+			expectedStatus: http.StatusNoContent,
+			modifiedUserID: "00000006-0000-0000-0000-000000000002",
+			modifiedUser:   "username1",
+			oldPassword:    validUserPassword,
+			newPassword:    "updated-password-3",
 		},
 		{
-			description:          "failed request for user changing their own password with the wrong old password",
-			username:             "username6",
-			password:             "password6",
-			expectedStatus:       http.StatusBadRequest,
-			modifiedUserIDorName: "username6",
-			oldPassword:          "password6-wrong",
-			newPassword:          "updated-password-4",
-			shouldSucceed:        false,
+			description:    "failed request for user changing their own password with the wrong old password",
+			username:       "username6",
+			password:       "password6",
+			expectedStatus: http.StatusBadRequest,
+			modifiedUserID: "00000006-0000-0000-0000-000000000007",
+			modifiedUser:   "username6",
+			oldPassword:    "password6-wrong",
+			newPassword:    "updated-password-4",
 		},
 		{
-			description:          "failed request for keycloak user",
-			username:             "admin",
-			password:             validAdminPassword,
-			expectedStatus:       http.StatusUnprocessableEntity,
-			modifiedUserIDorName: "delete-keycloak-user-1",
-			oldPassword:          "",
-			newPassword:          "keycloak-password-1",
-			shouldSucceed:        false,
+			description:    "failed request for keycloak user",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			modifiedUserID: "00000014-0000-0000-0000-000000000004",
+			modifiedUser:   "delete-keycloak-user-1",
+			oldPassword:    "",
+			newPassword:    "keycloak-password-1",
+		},
+		{
+			description:    "failed request with invalid UUID",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			modifiedUserID: "not-a-uuid",
+			modifiedUser:   "not-a-uuid",
+			oldPassword:    "",
+			newPassword:    "some-new-password-1",
 		},
 	}
 
@@ -1499,7 +1510,7 @@ func TestPutPassword(t *testing.T) {
 
 			t.Log(string(b))
 
-			req, err := http.NewRequest("PUT", ts.URL+"/api/v1/users/"+test.modifiedUserIDorName+"/local-password", r)
+			req, err := http.NewRequest("PUT", ts.URL+"/api/v1/users/"+test.modifiedUserID+"/local-password", r)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -1529,27 +1540,30 @@ func TestPutPassword(t *testing.T) {
 
 			t.Logf("%s\n", jsonData)
 
-			// Verify old password no longer works
-			statusCode, err := testAuth(t, ts, test.modifiedUserIDorName, test.oldPassword)
-			if err == nil {
-				t.Fatal(errors.New("old password still works, unexpected"))
-			}
-			if statusCode != http.StatusUnauthorized {
-				t.Fatal(fmt.Errorf("unexected status code: %d", statusCode))
+			// Verify password state is consistent with the expected outcome.
+			// Only testable when the modified user has a valid UUID
+			// (keycloak users and invalid UUIDs cannot be verified via
+			// basic auth).
+			var checkUUID pgtype.UUID
+			if checkUUID.Scan(test.modifiedUserID) != nil {
+				return
 			}
 
-			// Verify new password works
-			statusCode, err = testAuth(t, ts, test.modifiedUserIDorName, test.newPassword)
-			if err != nil {
-				if test.shouldSucceed {
+			if test.expectedStatus == http.StatusNoContent {
+				// Password was changed: new password must work
+				statusCode, err := testAuth(t, ts, test.modifiedUser, test.modifiedUserID, test.newPassword)
+				if err != nil {
 					t.Fatal(err)
 				}
-			}
-			if test.shouldSucceed {
 				if statusCode != http.StatusOK {
 					t.Fatal(fmt.Errorf("unexected status code: %d", statusCode))
 				}
 			} else {
+				// Password was NOT changed: new password must not work
+				statusCode, err := testAuth(t, ts, test.modifiedUser, test.modifiedUserID, test.newPassword)
+				if err == nil {
+					t.Fatal(errors.New("new password works after failed update, unexpected"))
+				}
 				if statusCode != http.StatusUnauthorized {
 					t.Fatal(fmt.Errorf("unexected status code: %d", statusCode))
 				}
@@ -1558,8 +1572,8 @@ func TestPutPassword(t *testing.T) {
 	}
 }
 
-func testAuth(t *testing.T, ts *httptest.Server, username string, password string) (int, error) {
-	req, err := http.NewRequest("GET", ts.URL+"/api/v1/users/"+username, nil)
+func testAuth(t *testing.T, ts *httptest.Server, username string, userID string, password string) (int, error) {
+	req, err := http.NewRequest("GET", ts.URL+"/api/v1/users/"+userID, nil)
 	if err != nil {
 		return 0, err
 	}
@@ -8952,7 +8966,7 @@ func TestConsoleCreateUser(t *testing.T) {
 		{
 			description: "successful user creation",
 			formData: url.Values{
-				"name":             {"test-console-user"},
+				"display_name":     {"test-console-user"},
 				"role":             {"user"},
 				"org":              {"org1"},
 				"password":         {"testpassword12345"},
@@ -8963,7 +8977,7 @@ func TestConsoleCreateUser(t *testing.T) {
 		{
 			description: "password mismatch",
 			formData: url.Values{
-				"name":             {"test-mismatch-user"},
+				"display_name":     {"test-mismatch-user"},
 				"role":             {"user"},
 				"org":              {cdntypes.OrgNotSelected},
 				"password":         {"testpassword12345"},
@@ -8974,7 +8988,7 @@ func TestConsoleCreateUser(t *testing.T) {
 		{
 			description: "password too short",
 			formData: url.Values{
-				"name":             {"test-short-pw-user"},
+				"display_name":     {"test-short-pw-user"},
 				"role":             {"user"},
 				"org":              {cdntypes.OrgNotSelected},
 				"password":         {"short"},
@@ -8985,7 +8999,7 @@ func TestConsoleCreateUser(t *testing.T) {
 		{
 			description: "duplicate name",
 			formData: url.Values{
-				"name":             {"admin"},
+				"display_name":     {"admin"},
 				"role":             {"admin"},
 				"org":              {cdntypes.OrgNotSelected},
 				"password":         {"testpassword12345"},
@@ -9069,38 +9083,45 @@ func TestConsoleEditUser(t *testing.T) {
 		path             string
 		formData         url.Values
 		expectRedirect   bool
+		expectedStatus   int
 		expectedErrorMsg string
 	}{
 		{
 			description: "GET edit form for existing user",
 			method:      "GET",
-			path:        "/console/superuser/users/username1/edit",
+			path:        "/console/superuser/users/00000006-0000-0000-0000-000000000002/edit",
 		},
 		{
 			description:      "GET edit form for non-existent user",
 			method:           "GET",
-			path:             "/console/superuser/users/nonexistent-user/edit",
+			path:             "/console/superuser/users/00000000-0000-0000-0000-000000000000/edit",
 			expectedErrorMsg: consoleUserNotFound,
+		},
+		{
+			description:    "GET edit form with invalid UUID returns 400",
+			method:         "GET",
+			path:           "/console/superuser/users/not-a-uuid/edit",
+			expectedStatus: http.StatusBadRequest,
 		},
 		{
 			description: "POST edit to change user role",
 			method:      "POST",
-			path:        "/console/superuser/users/username6/edit",
+			path:        "/console/superuser/users/00000006-0000-0000-0000-000000000007/edit",
 			formData: url.Values{
-				"name": {"username6"},
-				"role": {"admin"},
-				"org":  {cdntypes.OrgNotSelected},
+				"display_name": {"username6"},
+				"role":         {"admin"},
+				"org":          {cdntypes.OrgNotSelected},
 			},
 			expectRedirect: true,
 		},
 		{
 			description: "POST edit non-existent user",
 			method:      "POST",
-			path:        "/console/superuser/users/nonexistent-user/edit",
+			path:        "/console/superuser/users/00000000-0000-0000-0000-000000000000/edit",
 			formData: url.Values{
-				"name": {"nonexistent-user"},
-				"role": {"user"},
-				"org":  {cdntypes.OrgNotSelected},
+				"display_name": {"nonexistent-user"},
+				"role":         {"user"},
+				"org":          {cdntypes.OrgNotSelected},
 			},
 			expectedErrorMsg: consoleUserNotFound,
 		},
@@ -9134,6 +9155,17 @@ func TestConsoleEditUser(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer resp.Body.Close()
+
+			if test.expectedStatus == http.StatusBadRequest {
+				if resp.StatusCode != http.StatusBadRequest {
+					body, readErr := io.ReadAll(resp.Body)
+					if readErr != nil {
+						t.Fatal(readErr)
+					}
+					t.Fatalf("expected 400, got %d (%s)", resp.StatusCode, string(body))
+				}
+				return
+			}
 
 			if test.expectRedirect {
 				if resp.StatusCode != http.StatusSeeOther {
@@ -9181,22 +9213,28 @@ func TestConsoleDeleteUser(t *testing.T) {
 		description      string
 		userToDelete     string
 		expectRedirect   bool
+		expectedStatus   int
 		expectedErrorMsg string
 	}{
 		{
 			description:      "self-delete is prevented",
-			userToDelete:     "admin",
+			userToDelete:     "00000006-0000-0000-0000-000000000001",
 			expectedErrorMsg: consoleNotAllowedDeleteSelf,
 		},
 		{
 			description:      "delete non-existent user shows error",
-			userToDelete:     "nonexistent-user",
+			userToDelete:     "00000000-0000-0000-0000-000000000000",
 			expectedErrorMsg: consoleUserNotFound,
 		},
 		{
 			description:    "successful user deletion",
-			userToDelete:   "username5-no-pw",
+			userToDelete:   "00000006-0000-0000-0000-000000000006",
 			expectRedirect: true,
+		},
+		{
+			description:    "invalid UUID returns 400",
+			userToDelete:   "not-a-uuid",
+			expectedStatus: http.StatusBadRequest,
 		},
 	}
 
@@ -9220,6 +9258,17 @@ func TestConsoleDeleteUser(t *testing.T) {
 				t.Fatal(err)
 			}
 			defer resp.Body.Close()
+
+			if test.expectedStatus == http.StatusBadRequest {
+				if resp.StatusCode != http.StatusBadRequest {
+					body, readErr := io.ReadAll(resp.Body)
+					if readErr != nil {
+						t.Fatal(readErr)
+					}
+					t.Fatalf("expected 400, got %d (%s)", resp.StatusCode, string(body))
+				}
+				return
+			}
 
 			if test.expectRedirect {
 				if resp.StatusCode != http.StatusSeeOther {
@@ -9272,7 +9321,7 @@ func TestConsoleResetPassword(t *testing.T) {
 	}{
 		{
 			description: "successful password reset for local user",
-			userToReset: "username1",
+			userToReset: "00000006-0000-0000-0000-000000000002",
 			formData: url.Values{
 				"password":         {"newpassword12345"},
 				"confirm-password": {"newpassword12345"},
@@ -9281,7 +9330,7 @@ func TestConsoleResetPassword(t *testing.T) {
 		},
 		{
 			description: "password mismatch on reset",
-			userToReset: "username1",
+			userToReset: "00000006-0000-0000-0000-000000000002",
 			formData: url.Values{
 				"password":         {"newpassword12345"},
 				"confirm-password": {"differentpass1234"},
@@ -9290,7 +9339,7 @@ func TestConsoleResetPassword(t *testing.T) {
 		},
 		{
 			description: "password too short on reset",
-			userToReset: "username1",
+			userToReset: "00000006-0000-0000-0000-000000000002",
 			formData: url.Values{
 				"password":         {"short"},
 				"confirm-password": {"short"},
@@ -9299,7 +9348,7 @@ func TestConsoleResetPassword(t *testing.T) {
 		},
 		{
 			description: "reset password for non-existent user",
-			userToReset: "nonexistent-user",
+			userToReset: "00000000-0000-0000-0000-000000000000",
 			formData: url.Values{
 				"password":         {"newpassword12345"},
 				"confirm-password": {"newpassword12345"},


### PR DESCRIPTION
Users differ from other entities: their name comes from identity providers and is not a DNS-label identifier. Rename the DB column and Go fields from name to display_name to make this distinction explicit, and switch all user lookups from name-or-UUID to UUID-only.
This is relevant e.g. when we start building URLs for the console and cant be sure if the characters a given identity provider assigns to names are safe to include in the URL or not.

Breaking API change: JSON field "name" becomes "display_name" for all user endpoints, and path parameters now require UUIDs.

* Add migration renaming users.name column to display_name
* Update types, queries, handlers, and templates
* Remove newUserIdentifier() and userIdentifier (UUID-only now)
* Add itemLabel parameter to breadcrumbs for user display names
* Add invalid UUID test cases for all user API endpoints