### PR TITLE
Prevent UUID values in entity name columns

### DIFF
--- a/pkg/migrations/files/00006_name_not_uuid.sql
+++ b/pkg/migrations/files/00006_name_not_uuid.sql
@@ -1,0 +1,60 @@
+-- +goose up
+
+-- is_not_uuid returns true if the input is NOT a valid UUID.
+-- UUID parsing is deterministic with no side effects, so IMMUTABLE is
+-- correct despite the EXCEPTION block (which prevents inlining but
+-- does not affect correctness).
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION is_not_uuid(val text)
+RETURNS boolean AS $$
+BEGIN
+  PERFORM val::uuid;
+  RETURN false;
+EXCEPTION WHEN invalid_text_representation THEN
+  RETURN true;
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+-- +goose StatementEnd
+
+-- is_valid_name composes DNS label validation with UUID rejection.
+-- A valid name in this system is a DNS label that is not a UUID.
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION is_valid_name(name text)
+RETURNS boolean AS $$
+BEGIN
+  RETURN is_valid_dns_label(name) AND is_not_uuid(name);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+-- +goose StatementEnd
+
+-- Replace is_valid_dns_label constraints with is_valid_name on all
+-- 9 tables that use DNS label names.
+
+-- Tables with constraint named "valid_dns_label":
+ALTER TABLE orgs DROP CONSTRAINT valid_dns_label;
+ALTER TABLE orgs ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+ALTER TABLE services DROP CONSTRAINT valid_dns_label;
+ALTER TABLE services ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+ALTER TABLE cache_nodes DROP CONSTRAINT valid_dns_label;
+ALTER TABLE cache_nodes ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+ALTER TABLE l4lb_nodes DROP CONSTRAINT valid_dns_label;
+ALTER TABLE l4lb_nodes ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+ALTER TABLE node_groups DROP CONSTRAINT valid_dns_label;
+ALTER TABLE node_groups ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+ALTER TABLE service_origin_groups DROP CONSTRAINT valid_dns_label;
+ALTER TABLE service_origin_groups ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+ALTER TABLE org_keycloak_client_credentials DROP CONSTRAINT valid_dns_label;
+ALTER TABLE org_keycloak_client_credentials ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+-- Tables with constraint named "valid_dns_label_name":
+ALTER TABLE roles DROP CONSTRAINT valid_dns_label_name;
+ALTER TABLE roles ADD CONSTRAINT valid_name CHECK(is_valid_name(name));
+
+ALTER TABLE auth_providers DROP CONSTRAINT valid_dns_label_name;
+ALTER TABLE auth_providers ADD CONSTRAINT valid_name CHECK(is_valid_name(name));

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -3728,8 +3728,13 @@ func insertCacheNodeTx(ctx context.Context, tx pgx.Tx, name string, description 
 	err := tx.QueryRow(ctx, "INSERT INTO cache_nodes (name, description, maintenance) VALUES ($1, $2, $3) RETURNING id", name, description, maintenance).Scan(&cacheNodeID)
 	if err != nil {
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
-			return pgtype.UUID{}, cdnerrors.ErrAlreadyExists
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case pgUniqueViolation:
+				return pgtype.UUID{}, cdnerrors.ErrAlreadyExists
+			case pgCheckViolation:
+				return pgtype.UUID{}, cdnerrors.ErrCheckViolation
+			}
 		}
 		return pgtype.UUID{}, fmt.Errorf("INSERT cache node failed: %w", err)
 	}
@@ -3884,8 +3889,13 @@ func insertL4LBNodeTx(ctx context.Context, tx pgx.Tx, name string, description s
 	err := tx.QueryRow(ctx, "INSERT INTO l4lb_nodes (name, description, maintenance) VALUES ($1, $2, $3) RETURNING id", name, description, maintenance).Scan(&l4lbNodeID)
 	if err != nil {
 		var pgErr *pgconn.PgError
-		if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
-			return pgtype.UUID{}, cdnerrors.ErrAlreadyExists
+		if errors.As(err, &pgErr) {
+			switch pgErr.Code {
+			case pgUniqueViolation:
+				return pgtype.UUID{}, cdnerrors.ErrAlreadyExists
+			case pgCheckViolation:
+				return pgtype.UUID{}, cdnerrors.ErrCheckViolation
+			}
 		}
 		return pgtype.UUID{}, fmt.Errorf("INSERT l4lb node failed: %w", err)
 	}
@@ -4774,15 +4784,18 @@ func insertOrgClientCredential(ctx context.Context, logger *zerolog.Logger, dbc 
 		logger.Err(err).Msg("insertOrgClientCredential transaction failed")
 		if clientRegistered {
 			logger.Info().Msgf("operation failed after client was successfully registered, cleanup orphaned client: %s", clientID)
-			err = kcClientManager.deleteClientCred(clientID, registrationAccessToken)
-			if err != nil {
-				logger.Err(err).Msgf("unable to cleanup orphaned client credential from keycloak service, client ID: %s", clientID)
+			cleanupErr := kcClientManager.deleteClientCred(clientID, registrationAccessToken)
+			if cleanupErr != nil {
+				logger.Err(cleanupErr).Msgf("unable to cleanup orphaned client credential from keycloak service, client ID: %s", clientID)
 			}
 		}
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
-			if pgErr.Code == pgUniqueViolation {
+			switch pgErr.Code {
+			case pgUniqueViolation:
 				return cdntypes.NewOrgClientCredential{}, cdnerrors.ErrAlreadyExists
+			case pgCheckViolation:
+				return cdntypes.NewOrgClientCredential{}, cdnerrors.ErrCheckViolation
 			}
 		}
 		return cdntypes.NewOrgClientCredential{}, fmt.Errorf("insertOrgClientCredential transaction failed: %w", err)
@@ -5867,8 +5880,11 @@ func insertOriginGroupTx(ctx context.Context, tx pgx.Tx, serviceID pgtype.UUID, 
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
-			if pgErr.Code == pgUniqueViolation {
+			switch pgErr.Code {
+			case pgUniqueViolation:
 				return pgtype.UUID{}, cdnerrors.ErrAlreadyExists
+			case pgCheckViolation:
+				return pgtype.UUID{}, cdnerrors.ErrCheckViolation
 			}
 		}
 		return pgtype.UUID{}, fmt.Errorf("unable to insert origin group %s into service_origin_groups: %w", name, err)
@@ -6012,8 +6028,11 @@ func insertNodeGroupTx(ctx context.Context, tx pgx.Tx, name string, description 
 	if err != nil {
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
-			if pgErr.Code == pgUniqueViolation {
+			switch pgErr.Code {
+			case pgUniqueViolation:
 				return pgtype.UUID{}, cdnerrors.ErrAlreadyExists
+			case pgCheckViolation:
+				return pgtype.UUID{}, cdnerrors.ErrCheckViolation
 			}
 		}
 		return pgtype.UUID{}, fmt.Errorf("unable to insert node group %s into node_groups: %w", name, err)
@@ -6192,8 +6211,11 @@ func insertService(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, nam
 		logger.Err(err).Msg("insertService transaction failed")
 		var pgErr *pgconn.PgError
 		if errors.As(err, &pgErr) {
-			if pgErr.Code == pgUniqueViolation {
+			switch pgErr.Code {
+			case pgUniqueViolation:
 				return pgtype.UUID{}, cdnerrors.ErrAlreadyExists
+			case pgCheckViolation:
+				return pgtype.UUID{}, cdnerrors.ErrCheckViolation
 			}
 		}
 		return pgtype.UUID{}, fmt.Errorf("insertService transaction failed: %w", err)
@@ -8190,6 +8212,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 						return nil, huma.Error409Conflict("client credential already exists")
 					case errors.Is(err, cdnerrors.ErrUnprocessable):
 						return nil, huma.Error422UnprocessableEntity("missing required params")
+					case errors.Is(err, cdnerrors.ErrCheckViolation):
+						return nil, huma.Error422UnprocessableEntity("invalid client credential data")
 					}
 					logger.Err(err).Msg("unable to add client credential")
 					return nil, err
@@ -8626,6 +8650,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 						return nil, huma.Error403Forbidden("not allowed to create this service")
 					case errors.Is(err, cdnerrors.ErrServiceQuotaHit):
 						return nil, huma.Error409Conflict("service quota hit, not allowed to create more services")
+					case errors.Is(err, cdnerrors.ErrCheckViolation):
+						return nil, huma.Error422UnprocessableEntity("invalid service data")
 					}
 					logger.Err(err).Msg("unable to add service")
 					return nil, err
@@ -8868,6 +8894,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 						return nil, huma.Error409Conflict("origin group already exists")
 					case errors.Is(err, cdnerrors.ErrForbidden):
 						return nil, huma.Error403Forbidden("not allowed to create this origin group")
+					case errors.Is(err, cdnerrors.ErrCheckViolation):
+						return nil, huma.Error422UnprocessableEntity("invalid origin group data")
 					}
 					logger.Err(err).Msg("unable to add origin group")
 					return nil, err
@@ -9083,6 +9111,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 						return nil, huma.Error409Conflict(addrErr.Error())
 					case errors.Is(err, cdnerrors.ErrAlreadyExists):
 						return nil, huma.Error409Conflict("cache node already exists")
+					case errors.Is(err, cdnerrors.ErrCheckViolation):
+						return nil, huma.Error422UnprocessableEntity("invalid cache node data")
 					default:
 						logger.Err(err).Msg("unable to add cache node")
 						return nil, err
@@ -9207,6 +9237,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 						return nil, huma.Error409Conflict(addrErr.Error())
 					case errors.Is(err, cdnerrors.ErrAlreadyExists):
 						return nil, huma.Error409Conflict("l4lb node already exists")
+					case errors.Is(err, cdnerrors.ErrCheckViolation):
+						return nil, huma.Error422UnprocessableEntity("invalid l4lb node data")
 					default:
 						logger.Err(err).Msg("unable to add l4lb node")
 						return nil, err
@@ -9323,6 +9355,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 						return nil, huma.Error409Conflict("node group already exists")
 					case errors.Is(err, cdnerrors.ErrForbidden):
 						return nil, huma.Error403Forbidden("not allowed to create this node group")
+					case errors.Is(err, cdnerrors.ErrCheckViolation):
+						return nil, huma.Error422UnprocessableEntity("invalid node group data")
 					}
 					logger.Err(err).Msg("unable to add node group")
 					return nil, err
@@ -9363,6 +9397,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 					return nil, huma.Error409Conflict(addrErr.Error())
 				case errors.Is(err, cdnerrors.ErrAlreadyExists):
 					return nil, huma.Error409Conflict("cache node already exists")
+				case errors.Is(err, cdnerrors.ErrCheckViolation):
+					return nil, huma.Error422UnprocessableEntity("invalid cache node data")
 				default:
 					return nil, fmt.Errorf("unable to update cache node: %w", err)
 				}
@@ -9424,6 +9460,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 					return nil, huma.Error409Conflict(addrErr.Error())
 				case errors.Is(err, cdnerrors.ErrAlreadyExists):
 					return nil, huma.Error409Conflict("l4lb node already exists")
+				case errors.Is(err, cdnerrors.ErrCheckViolation):
+					return nil, huma.Error422UnprocessableEntity("invalid l4lb node data")
 				default:
 					return nil, fmt.Errorf("unable to update l4lb node: %w", err)
 				}
@@ -9478,6 +9516,8 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 					return nil, huma.Error404NotFound(nodeGroupNotFound)
 				case errors.Is(err, cdnerrors.ErrAlreadyExists):
 					return nil, huma.Error409Conflict("node group already exists")
+				case errors.Is(err, cdnerrors.ErrCheckViolation):
+					return nil, huma.Error422UnprocessableEntity("invalid node group data")
 				default:
 					return nil, fmt.Errorf("unable to update node group: %w", err)
 				}
@@ -13106,8 +13146,13 @@ func updateCacheNode(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, cac
 			name, description, cacheNodeIdent.id).Scan(&maintenance)
 		if err != nil {
 			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
-				return cdnerrors.ErrAlreadyExists
+			if errors.As(err, &pgErr) {
+				switch pgErr.Code {
+				case pgUniqueViolation:
+					return cdnerrors.ErrAlreadyExists
+				case pgCheckViolation:
+					return cdnerrors.ErrCheckViolation
+				}
 			}
 			return fmt.Errorf("updateCacheNode: UPDATE failed: %w", err)
 		}
@@ -13174,8 +13219,13 @@ func updateL4LBNode(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, l4lb
 			name, description, l4lbNodeIdent.id).Scan(&maintenance)
 		if err != nil {
 			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
-				return cdnerrors.ErrAlreadyExists
+			if errors.As(err, &pgErr) {
+				switch pgErr.Code {
+				case pgUniqueViolation:
+					return cdnerrors.ErrAlreadyExists
+				case pgCheckViolation:
+					return cdnerrors.ErrCheckViolation
+				}
 			}
 			return fmt.Errorf("updateL4LBNode: UPDATE failed: %w", err)
 		}
@@ -13241,8 +13291,13 @@ func updateNodeGroup(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, nod
 			name, description, nodeGroupIdent.id)
 		if err != nil {
 			var pgErr *pgconn.PgError
-			if errors.As(err, &pgErr) && pgErr.Code == pgUniqueViolation {
-				return cdnerrors.ErrAlreadyExists
+			if errors.As(err, &pgErr) {
+				switch pgErr.Code {
+				case pgUniqueViolation:
+					return cdnerrors.ErrAlreadyExists
+				case pgCheckViolation:
+					return cdnerrors.ErrCheckViolation
+				}
 			}
 			return fmt.Errorf("updateNodeGroup: UPDATE failed: %w", err)
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/coreos/go-oidc/v3/oidc"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/lestrrat-go/jwx/v3/jwk"
@@ -50,6 +51,9 @@ import (
 const (
 	validAdminPassword = "adminpass123456"
 	validUserPassword  = "userpass1234567"
+
+	// Constraint name from migration 00006_name_not_uuid.sql
+	pgConstraintValidName = "valid_name"
 )
 
 var pgt *postgrestest.Server
@@ -2705,7 +2709,11 @@ func TestPostDeleteOrgClientCredentials(t *testing.T) {
 }
 
 func TestPostOrgClientCredentialsInvalidName(t *testing.T) {
-	ts, dbPool, err := prepareServer(t, testServerInput{})
+	ctx := context.Background()
+	_, kcClientManager, issuerURL, jwkCache, oiConf, jwkCancelFunc := createKeycloakContainer(ctx, t)
+	defer jwkCancelFunc()
+
+	ts, dbPool, err := prepareServer(t, testServerInput{kcClientManager: kcClientManager, jwkCache: jwkCache, jwtIssuer: issuerURL.String(), oiConf: oiConf})
 	if dbPool != nil {
 		defer dbPool.Close()
 	}
@@ -2728,6 +2736,16 @@ func TestPostOrgClientCredentialsInvalidName(t *testing.T) {
 			password:       validAdminPassword,
 			expectedStatus: http.StatusUnprocessableEntity,
 			credName:       "INVALID NAME",
+			orgNameOrID:    "org1",
+		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint.
+			description:    "failed superuser request with UUID name",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			credName:       "abcdef01-2345-6789-abcd-ef0123456789",
 			orgNameOrID:    "org1",
 		},
 	}
@@ -3427,6 +3445,15 @@ func TestPostOrganizations(t *testing.T) {
 			addedOrganization: "username1org",
 			expectedStatus:    http.StatusForbidden,
 		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:       "failed superuser request with UUID name",
+			username:          "admin",
+			password:          validAdminPassword,
+			expectedStatus:    http.StatusUnprocessableEntity,
+			addedOrganization: "abcdef01-2345-6789-abcd-ef0123456789",
+		},
 	}
 
 	for _, test := range tests {
@@ -3983,6 +4010,16 @@ func TestPostServices(t *testing.T) {
 			newService:     "new-admin-org-4-service2",
 			expectedStatus: http.StatusConflict,
 			org:            "org4",
+		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:    "failed superuser request with UUID name",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			newService:     "abcdef01-2345-6789-abcd-ef0123456789",
+			org:            "org1",
 		},
 	}
 
@@ -5138,6 +5175,17 @@ func TestPostOriginGroups(t *testing.T) {
 			name:            "INVALID NAME",
 			expectedStatus:  http.StatusUnprocessableEntity,
 		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:     "failed superuser request with UUID name",
+			username:        "admin",
+			password:        validAdminPassword,
+			orgNameOrID:     "00000002-0000-0000-0000-000000000001",
+			serviceNameOrID: "00000003-0000-0000-0000-000000000001",
+			name:            "abcdef01-2345-6789-abcd-ef0123456789",
+			expectedStatus:  http.StatusUnprocessableEntity,
+		},
 	}
 
 	for _, test := range tests {
@@ -5917,6 +5965,17 @@ func TestPostCacheNodes(t *testing.T) {
 			expectedStatus: http.StatusForbidden,
 			name:           "cache-node-post-user-7",
 		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:    "failed superuser request with UUID name",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			cacheNodeDescr: "uuid-name-test.example.com",
+			addresses:      []netip.Addr{netip.MustParseAddr("127.0.0.50")},
+			name:           "abcdef01-2345-6789-abcd-ef0123456789",
+		},
 	}
 
 	for _, test := range tests {
@@ -6541,6 +6600,17 @@ func TestPostL4LBNodes(t *testing.T) {
 			expectedStatus: http.StatusForbidden,
 			name:           "l4lb-node-post-user-7",
 		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:    "failed superuser request with UUID name",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			l4lbNodeDescr:  "uuid-name-test.example.com",
+			addresses:      []netip.Addr{netip.MustParseAddr("127.0.0.50")},
+			name:           "abcdef01-2345-6789-abcd-ef0123456789",
+		},
 	}
 
 	for _, test := range tests {
@@ -6967,6 +7037,16 @@ func TestPostNodeGroups(t *testing.T) {
 			groupDescription: "some node group",
 			expectedStatus:   http.StatusCreated,
 		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:      "failed superuser request with UUID name",
+			username:         "admin",
+			password:         validAdminPassword,
+			name:             "abcdef01-2345-6789-abcd-ef0123456789",
+			groupDescription: "uuid name test",
+			expectedStatus:   http.StatusUnprocessableEntity,
+		},
 	}
 
 	for _, test := range tests {
@@ -7087,6 +7167,18 @@ func TestPutCacheNode(t *testing.T) {
 			cacheNode:      "nonexistent-node",
 			name:           "nonexistent-node",
 			nodeDescr:      "Should not work",
+			addresses:      []netip.Addr{netip.MustParseAddr("10.0.0.1")},
+		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:    "failed superuser request, UUID name",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			cacheNode:      "cache-node1",
+			name:           "abcdef01-2345-6789-abcd-ef0123456789",
+			nodeDescr:      "UUID rename test",
 			addresses:      []netip.Addr{netip.MustParseAddr("10.0.0.1")},
 		},
 	}
@@ -7329,6 +7421,18 @@ func TestPutL4LBNode(t *testing.T) {
 			nodeDescr:      "Should not work",
 			addresses:      []netip.Addr{netip.MustParseAddr("10.0.0.2")},
 		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:    "failed superuser request, UUID name",
+			username:       "admin",
+			password:       validAdminPassword,
+			expectedStatus: http.StatusUnprocessableEntity,
+			l4lbNode:       "l4lb-node1",
+			name:           "abcdef01-2345-6789-abcd-ef0123456789",
+			nodeDescr:      "UUID rename test",
+			addresses:      []netip.Addr{netip.MustParseAddr("10.0.0.2")},
+		},
 	}
 
 	for _, test := range tests {
@@ -7562,6 +7666,17 @@ func TestPutNodeGroup(t *testing.T) {
 			nodeGroup:        "nonexistent-group",
 			name:             "nonexistent-group",
 			groupDescription: "Should not work",
+		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:      "failed superuser request, UUID name",
+			username:         "admin",
+			password:         validAdminPassword,
+			expectedStatus:   http.StatusUnprocessableEntity,
+			nodeGroup:        "node-group-2",
+			name:             "abcdef01-2345-6789-abcd-ef0123456789",
+			groupDescription: "UUID rename test",
 		},
 	}
 
@@ -8244,6 +8359,19 @@ func TestPutOrganization(t *testing.T) {
 			expectedStatus:   http.StatusUnprocessableEntity,
 			org:              "org1",
 			name:             "INVALID NAME",
+			serviceQuota:     10,
+			domainQuota:      20,
+			clientTokenQuota: 30,
+		},
+		{
+			// UUID starts with a letter to bypass Huma's DNS label pattern
+			// validation — this exercises the database CHECK constraint
+			description:      "failed superuser request, UUID name",
+			username:         "admin",
+			password:         validAdminPassword,
+			expectedStatus:   http.StatusUnprocessableEntity,
+			org:              "org1",
+			name:             "abcdef01-2345-6789-abcd-ef0123456789",
 			serviceQuota:     10,
 			domainQuota:      20,
 			clientTokenQuota: 30,
@@ -9406,6 +9534,67 @@ func TestConsoleResetPassword(t *testing.T) {
 						t.Fatalf("expected error text to contain %q, got %q", test.expectedErrorMsg, errorText)
 					}
 				}
+			}
+		})
+	}
+}
+
+func TestNameNotUUIDConstraint(t *testing.T) {
+	ctx := context.Background()
+	logger := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Caller().Logger()
+
+	dbPool, err := initDatabase(ctx, t, logger, false)
+	if dbPool != nil {
+		defer dbPool.Close()
+	}
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// UUIDs that start with a letter (a-f) pass the is_valid_dns_label()
+	// regex but should be rejected by is_valid_name() which also checks
+	// is_not_uuid(). This tests the database constraint directly for
+	// entities that have no API POST endpoint.
+	tests := []struct {
+		description string
+		query       string
+		uuid        string
+	}{
+		{
+			description: "roles rejects hyphenated UUID name",
+			query:       "INSERT INTO roles (name) VALUES ($1)",
+			uuid:        "abcdef01-2345-6789-abcd-ef0123456789",
+		},
+		{
+			description: "auth_providers rejects hyphenated UUID name",
+			query:       "INSERT INTO auth_providers (name) VALUES ($1)",
+			uuid:        "abcdef01-2345-6789-abcd-ef0123456789",
+		},
+		{
+			description: "roles rejects non-hyphenated UUID name",
+			query:       "INSERT INTO roles (name) VALUES ($1)",
+			uuid:        "abcdef012345678901234567890abcde",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			_, err := dbPool.Exec(context.Background(), test.query, test.uuid)
+			if err == nil {
+				t.Fatal("expected INSERT to fail with check constraint violation, but it succeeded")
+			}
+
+			var pgErr *pgconn.PgError
+			if !errors.As(err, &pgErr) {
+				t.Fatalf("expected pgconn.PgError, got: %v", err)
+			}
+
+			if pgErr.Code != pgCheckViolation {
+				t.Fatalf("expected check_violation (23514), got: %s", pgErr.Code)
+			}
+
+			if pgErr.ConstraintName != pgConstraintValidName {
+				t.Fatalf("expected constraint %s, got: %s", pgConstraintValidName, pgErr.ConstraintName)
 			}
 		})
 	}


### PR DESCRIPTION
Add database CHECK constraint via is_valid_name() that composes is_valid_dns_label() with a new is_not_uuid() function, preventing name/id ambiguity in identifier resolution. Applied to all 9 tables with DNS label name columns.

Add pgCheckViolation -> ErrCheckViolation -> 422 error handling to all INSERT/UPDATE DB functions and their corresponding API handlers. Fix pre-existing bug where Keycloak client cleanup overwrote the original error variable in insertOrgClientCredential().