### PR TITLE
Rename domains.name column to domains.fqdn

### DIFF
--- a/pkg/cdntypes/cdntypes.go
+++ b/pkg/cdntypes/cdntypes.go
@@ -244,7 +244,7 @@ func camelCaseToSnakeCase(s string) string {
 
 type Domain struct {
 	ID                pgtype.UUID `json:"id"`
-	Name              string      `json:"name"`
+	FQDN              string      `json:"fqdn"`
 	Verified          bool        `json:"verified"`
 	VerificationToken string      `json:"verification_token"`
 }
@@ -325,7 +325,7 @@ type ServiceVersionWithConfig struct {
 	Active        bool           `json:"active" example:"true" doc:"If the version is active"`
 	VCL           string         `json:"vcl"`
 	TLS           bool           `json:"tls" example:"true" doc:"If at least one origin has TLS enabled which means we require certificates"`
-	Domains       []DomainString `json:"domains" doc:"Names that the service is listening on"`
+	Domains       []DomainString `json:"domains" doc:"FQDNs that the service is listening on"`
 	HAProxyConfig string         `json:"haproxy_config"`
 }
 

--- a/pkg/components/components.go
+++ b/pkg/components/components.go
@@ -25,7 +25,7 @@ var CSSFS embed.FS
 var JsFS embed.FS
 
 type DomainFormFields struct {
-	Name string
+	FQDN string
 }
 
 type DomainData struct {

--- a/pkg/components/console.templ
+++ b/pkg/components/console.templ
@@ -212,19 +212,19 @@ templ DomainsContent(orgName string, domains []cdntypes.Domain, verificationTag 
 			<tbody>
 				for _, domain := range domains {
 					<tr>
-						<td>{ domain.Name }</td>
+						<td>{ domain.FQDN }</td>
 						if domain.Verified {
 							<td><span aria-hidden="true">✅ </span>Yes</td>
 						} else {
 							<td><span aria-hidden="true">⏳ </span>In progress</td>
 						}
-						<td>{ domain.Name }. IN TXT "{ verificationTag }{ tagSeparator }{ domain.VerificationToken }"</td>
+						<td>{ domain.FQDN }. IN TXT "{ verificationTag }{ tagSeparator }{ domain.VerificationToken }"</td>
 						<td>
 							<button
 								type="button"
-								hx-delete={ string(templ.URL(fmt.Sprintf("/console/org/%s/domains/%s", orgName, domain.Name))) }
+								hx-delete={ string(templ.URL(fmt.Sprintf("/console/org/%s/domains/%s", orgName, domain.FQDN))) }
 								hx-target="body"
-								hx-confirm={ fmt.Sprintf("Are you sure you want to delete '%s'?", domain.Name) }
+								hx-confirm={ fmt.Sprintf("Are you sure you want to delete '%s'?", domain.FQDN) }
 								hx-disabled-elt="this"
 							>
 								Delete
@@ -416,11 +416,11 @@ templ CreateDomainContent(orgName string, dData DomainData) {
 		<span class="error-text" role="alert" aria-live="polite">{ dData.Errors.ServerError }</span>
 	}
 	<form method="post" action={ templ.URL(fmt.Sprintf("/console/org/%s/create/domain", orgName)) } hx-disabled-elt="find button[type='submit']">
-		<label for="name">
-			Name
-			<input type="text" id="name" name="name" placeholder="Enter domain name..." value={ dData.Name } required/>
+		<label for="fqdn">
+			FQDN
+			<input type="text" id="fqdn" name="fqdn" placeholder="Enter domain name..." value={ dData.FQDN } required/>
 		</label>
-		<span class="error-text">{ dData.Errors.Name }</span>
+		<span class="error-text">{ dData.Errors.FQDN }</span>
 		<button type="submit">Add domain</button>
 	</form>
 }
@@ -727,25 +727,25 @@ templ CreateServiceVersionContent(serviceName string, orgName string, vclSK cdnt
 					for i, domain := range domains {
 						if domain.Verified {
 							<label for={ fmt.Sprintf("domains.%d", i) }>
-								{ domain.Name }
+								{ domain.FQDN }
 								{{
 									var precheck bool
 									if submittedData != nil {
 										for _, submittedDomain := range submittedData.Domains {
-											if string(submittedDomain) == domain.Name {
+											if string(submittedDomain) == domain.FQDN {
 												precheck = true
 												break
 											}
 										}
 									}
 									for _, cloneDomain := range cloneData.Domains {
-										if string(cloneDomain) == domain.Name {
+										if string(cloneDomain) == domain.FQDN {
 											precheck = true
 											break
 										}
 									}
 								}}
-								<input type="checkbox" id={ fmt.Sprintf("domains.%d", i) } name="domains" value={ domain.Name } checked?={ precheck }/>
+								<input type="checkbox" id={ fmt.Sprintf("domains.%d", i) } name="domains" value={ domain.FQDN } checked?={ precheck }/>
 							</label>
 						}
 					}

--- a/pkg/components/console_templ.go
+++ b/pkg/components/console_templ.go
@@ -948,7 +948,7 @@ func DomainsContent(orgName string, domains []cdntypes.Domain, verificationTag s
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var40 string
-				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(domain.Name)
+				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(domain.FQDN)
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 215, Col: 23}
 				}
@@ -976,7 +976,7 @@ func DomainsContent(orgName string, domains []cdntypes.Domain, verificationTag s
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var41 string
-				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(domain.Name)
+				templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(domain.FQDN)
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 221, Col: 23}
 				}
@@ -1020,7 +1020,7 @@ func DomainsContent(orgName string, domains []cdntypes.Domain, verificationTag s
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var45 string
-				templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(string(templ.URL(fmt.Sprintf("/console/org/%s/domains/%s", orgName, domain.Name))))
+				templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(string(templ.URL(fmt.Sprintf("/console/org/%s/domains/%s", orgName, domain.FQDN))))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 225, Col: 102}
 				}
@@ -1033,7 +1033,7 @@ func DomainsContent(orgName string, domains []cdntypes.Domain, verificationTag s
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var46 string
-				templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Are you sure you want to delete '%s'?", domain.Name))
+				templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(fmt.Sprintf("Are you sure you want to delete '%s'?", domain.FQDN))
 				if templ_7745c5c3_Err != nil {
 					return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 227, Col: 86}
 				}
@@ -1625,12 +1625,12 @@ func CreateDomainContent(orgName string, dData DomainData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 141, "\" hx-disabled-elt=\"find button[type='submit']\"><label for=\"name\">Name <input type=\"text\" id=\"name\" name=\"name\" placeholder=\"Enter domain name...\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 141, "\" hx-disabled-elt=\"find button[type='submit']\"><label for=\"fqdn\">FQDN <input type=\"text\" id=\"fqdn\" name=\"fqdn\" placeholder=\"Enter domain name...\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var77 string
-		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(dData.Name)
+		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(dData.FQDN)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 421, Col: 97}
 		}
@@ -1643,7 +1643,7 @@ func CreateDomainContent(orgName string, dData DomainData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var78 string
-		templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(dData.Errors.Name)
+		templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(dData.Errors.FQDN)
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 423, Col: 46}
 		}
@@ -2830,7 +2830,7 @@ func CreateServiceVersionContent(serviceName string, orgName string, vclSK cdnty
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var133 string
-					templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(domain.Name)
+					templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(domain.FQDN)
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 730, Col: 21}
 					}
@@ -2841,14 +2841,14 @@ func CreateServiceVersionContent(serviceName string, orgName string, vclSK cdnty
 					var precheck bool
 					if submittedData != nil {
 						for _, submittedDomain := range submittedData.Domains {
-							if string(submittedDomain) == domain.Name {
+							if string(submittedDomain) == domain.FQDN {
 								precheck = true
 								break
 							}
 						}
 					}
 					for _, cloneDomain := range cloneData.Domains {
-						if string(cloneDomain) == domain.Name {
+						if string(cloneDomain) == domain.FQDN {
 							precheck = true
 							break
 						}
@@ -2871,7 +2871,7 @@ func CreateServiceVersionContent(serviceName string, orgName string, vclSK cdnty
 						return templ_7745c5c3_Err
 					}
 					var templ_7745c5c3_Var135 string
-					templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(domain.Name)
+					templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(domain.FQDN)
 					if templ_7745c5c3_Err != nil {
 						return templ.Error{Err: templ_7745c5c3_Err, FileName: `console.templ`, Line: 748, Col: 101}
 					}

--- a/pkg/migrations/files/00007_rename_domains_name_to_fqdn.sql
+++ b/pkg/migrations/files/00007_rename_domains_name_to_fqdn.sql
@@ -1,0 +1,5 @@
+-- +goose up
+ALTER TABLE domains RENAME COLUMN name TO fqdn;
+ALTER TABLE domains RENAME CONSTRAINT non_empty_name TO non_empty_fqdn;
+ALTER TABLE domains RENAME CONSTRAINT domains_name_not_null TO domains_fqdn_not_null;
+ALTER INDEX domains_name_key RENAME TO domains_fqdn_key;

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1521,7 +1521,7 @@ func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 
 			domainData := components.DomainData{
 				DomainFormFields: components.DomainFormFields{
-					Name: formData.Name,
+					FQDN: formData.FQDN,
 				},
 			}
 
@@ -1529,11 +1529,11 @@ func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 			if err != nil {
 				validationErrors := err.(validator.ValidationErrors)
 				for _, fieldError := range validationErrors {
-					if fieldError.StructField() == "Name" {
+					if fieldError.StructField() == "FQDN" {
 						if fieldError.Tag() == "fqdn" {
-							domainData.Errors.Name = validationNotFQDN
+							domainData.Errors.FQDN = validationNotFQDN
 						} else {
-							domainData.Errors.Name = fieldError.Error()
+							domainData.Errors.FQDN = fieldError.Error()
 						}
 					}
 				}
@@ -1547,10 +1547,10 @@ func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 				return
 			}
 
-			_, err = insertDomain(ctx, logger, dbc, formData.Name, &orgIdent.name, ad)
+			_, err = insertDomain(ctx, logger, dbc, formData.FQDN, &orgIdent.name, ad)
 			if err != nil {
 				if errors.Is(err, cdnerrors.ErrAlreadyExists) {
-					domainData.Errors.Name = cdnerrors.ErrAlreadyExists.Error()
+					domainData.Errors.FQDN = cdnerrors.ErrAlreadyExists.Error()
 				} else {
 					logger.Err(err).Msg("unable to insert domain")
 					domainData.Errors.ServerError = "unable to insert domain"
@@ -1564,7 +1564,7 @@ func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 				return
 			}
 
-			session.AddFlash(fmt.Sprintf("Domain '%s' added!", formData.Name), flashMessageKeys.domains)
+			session.AddFlash(fmt.Sprintf("Domain '%s' added!", formData.FQDN), flashMessageKeys.domains)
 			err = session.Save(r, w)
 			if err != nil {
 				http.Error(w, unableToSetFlashMessage, http.StatusInternalServerError)
@@ -2086,7 +2086,7 @@ func getServiceVersionCloneData(ctx context.Context, tx pgx.Tx, ad cdntypes.Auth
 		ctx,
 		`SELECT
 			(SELECT
-				array_agg(domains.name ORDER BY domains.name)
+				array_agg(domains.fqdn ORDER BY domains.fqdn)
 				FROM domains
 				JOIN service_domains ON service_domains.domain_id = domains.id
 				WHERE domains.verified = true AND service_version_id = service_versions.id
@@ -2512,7 +2512,7 @@ type createServiceForm struct {
 type createDomainForm struct {
 	// Domain name length validation needs to be kept in sync with the CHECK
 	// constraints in the domains table, see the migrations module.
-	Name string `schema:"name" validate:"min=1,max=253,fqdn"`
+	FQDN string `schema:"fqdn" validate:"min=1,max=253,fqdn"`
 }
 
 type createAPITokenForm struct {
@@ -4268,12 +4268,12 @@ func selectDomains(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, orgNa
 
 		var rows pgx.Rows
 		if lookupOrg.Valid {
-			rows, err = tx.Query(ctx, "SELECT id, name, verified, verification_token FROM domains WHERE org_id=$1 ORDER BY name", lookupOrg)
+			rows, err = tx.Query(ctx, "SELECT id, fqdn, verified, verification_token FROM domains WHERE org_id=$1 ORDER BY fqdn", lookupOrg)
 			if err != nil {
 				return fmt.Errorf("unable to query for domains for specific org: %w", err)
 			}
 		} else {
-			rows, err = tx.Query(ctx, "SELECT id, name, verified, verification_token FROM domains ORDER BY name")
+			rows, err = tx.Query(ctx, "SELECT id, fqdn, verified, verification_token FROM domains ORDER BY fqdn")
 			if err != nil {
 				return fmt.Errorf("unable to query for all domains: %w", err)
 			}
@@ -4293,7 +4293,7 @@ func selectDomains(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData, orgNa
 	return domains, nil
 }
 
-func deleteDomain(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, ad cdntypes.AuthData, domainNameOrID string) (pgtype.UUID, error) {
+func deleteDomain(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, ad cdntypes.AuthData, domainFQDNOrID string) (pgtype.UUID, error) {
 	if !ad.Superuser && ad.OrgID == nil {
 		return pgtype.UUID{}, cdnerrors.ErrNotFound
 	}
@@ -4303,7 +4303,7 @@ func deleteDomain(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, ad c
 
 	var domainID pgtype.UUID
 	err := pgx.BeginFunc(dbCtx, dbc.dbPool, func(tx pgx.Tx) error {
-		domainIdent, err := newDomainIdentifier(dbCtx, tx, domainNameOrID)
+		domainIdent, err := newDomainIdentifier(dbCtx, tx, domainFQDNOrID)
 		if err != nil {
 			if errors.Is(err, pgx.ErrNoRows) {
 				return cdnerrors.ErrNotFound
@@ -5379,8 +5379,11 @@ type nodeGroupIdentifier struct {
 	resourceIdentifier
 }
 
+// domainIdentifier does not embed resourceIdentifier because domains
+// use an FQDN instead of the DNS-label "name" other resources use.
 type domainIdentifier struct {
-	resourceIdentifier
+	id    pgtype.UUID
+	fqdn  string
 	orgID pgtype.UUID
 }
 
@@ -5598,30 +5601,28 @@ func newDomainIdentifier(ctx context.Context, tx pgx.Tx, input string) (domainId
 	}
 
 	var id pgtype.UUID
-	var name string
+	var fqdn string
 	var orgID pgtype.UUID
 
 	inputID := new(pgtype.UUID)
 	err := inputID.Scan(input)
 	if err == nil {
-		// This is a valid UUID, treat it as an ID and collect the name (also verifying the id exists in the process)
-		err := tx.QueryRow(ctx, "SELECT id, name, org_id FROM domains WHERE id = $1 FOR SHARE", *inputID).Scan(&id, &name, &orgID)
+		// This is a valid UUID, treat it as an ID and collect the FQDN (also verifying the id exists in the process)
+		err := tx.QueryRow(ctx, "SELECT id, fqdn, org_id FROM domains WHERE id = $1 FOR SHARE", *inputID).Scan(&id, &fqdn, &orgID)
 		if err != nil {
 			return domainIdentifier{}, err
 		}
 	} else {
-		// This is not a valid UUID, treat it as a name and validate it by mapping it to an ID (domain names are globally unique)
-		err := tx.QueryRow(ctx, "SELECT id, name, org_id FROM domains WHERE name = $1 FOR SHARE", input).Scan(&id, &name, &orgID)
+		// This is not a valid UUID, treat it as an FQDN and validate it by mapping it to an ID (domain FQDNs are globally unique)
+		err := tx.QueryRow(ctx, "SELECT id, fqdn, org_id FROM domains WHERE fqdn = $1 FOR SHARE", input).Scan(&id, &fqdn, &orgID)
 		if err != nil {
 			return domainIdentifier{}, err
 		}
 	}
 
 	return domainIdentifier{
-		resourceIdentifier: resourceIdentifier{
-			name: name,
-			id:   id,
-		},
+		id:    id,
+		fqdn:  fqdn,
 		orgID: orgID,
 	}, nil
 }
@@ -6040,12 +6041,12 @@ func insertNodeGroupTx(ctx context.Context, tx pgx.Tx, name string, description 
 	return nodeGroupID, nil
 }
 
-func insertDomain(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, name string, orgNameOrID *string, ad cdntypes.AuthData) (cdntypes.Domain, error) {
+func insertDomain(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, fqdn string, orgNameOrID *string, ad cdntypes.AuthData) (cdntypes.Domain, error) {
 	var domainID pgtype.UUID
 	var verificationToken string
 
-	// Cleanup any trailing "." in domain name
-	name = strings.TrimRight(name, ".")
+	// Cleanup any trailing "." in domain FQDN
+	fqdn = strings.TrimRight(fqdn, ".")
 
 	var orgIdent orgIdentifier
 	var err error
@@ -6099,7 +6100,7 @@ func insertDomain(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, name
 			return fmt.Errorf("failed generating verification token: %w", err)
 		}
 
-		err = tx.QueryRow(dbCtx, "INSERT INTO domains (name, verification_token, org_id) VALUES ($1, $2, $3) RETURNING id", name, verificationToken, orgIdent.id).Scan(&domainID)
+		err = tx.QueryRow(dbCtx, "INSERT INTO domains (fqdn, verification_token, org_id) VALUES ($1, $2, $3) RETURNING id", fqdn, verificationToken, orgIdent.id).Scan(&domainID)
 		if err != nil {
 			return fmt.Errorf("unable to INSERT domain: %w", err)
 		}
@@ -6119,7 +6120,7 @@ func insertDomain(ctx context.Context, logger *zerolog.Logger, dbc *dbConn, name
 
 	d := cdntypes.Domain{
 		ID:                domainID,
-		Name:              name,
+		FQDN:              fqdn,
 		Verified:          false,
 		VerificationToken: verificationToken,
 	}
@@ -6361,7 +6362,7 @@ func selectCacheNodeConfig(ctx context.Context, dbc *dbConn, ad cdntypes.AuthDat
 				GROUP BY service_id
 			) AS agg_service_ip_addresses ON agg_service_ip_addresses.service_id = services.id
 		       JOIN (
-			       SELECT service_version_id, array_agg(domains.name ORDER BY domains.name) AS domains
+			       SELECT service_version_id, array_agg(domains.fqdn ORDER BY domains.fqdn) AS domains
 			       FROM service_domains
 			       JOIN domains ON service_domains.domain_id = domains.id
 			       WHERE domains.verified = true
@@ -6866,7 +6867,7 @@ func getServiceVersionConfig(ctx context.Context, dbc *dbConn, ad cdntypes.AuthD
 				WHERE service_id = services.id
 			) AS service_ip_addresses,
 			(SELECT
-				array_agg(domains.name ORDER BY domains.name)
+				array_agg(domains.fqdn ORDER BY domains.fqdn)
 				FROM domains
 				JOIN service_domains ON service_domains.domain_id = domains.id
 				WHERE domains.verified = true AND service_version_id = service_versions.id
@@ -6987,7 +6988,7 @@ func insertServiceVersionTx(ctx context.Context, tx pgx.Tx, orgIdent orgIdentifi
 		var domainID pgtype.UUID
 		err = tx.QueryRow(
 			ctx,
-			"SELECT id FROM domains WHERE name=$1 AND org_id=$2 AND verified=$3",
+			"SELECT id FROM domains WHERE fqdn=$1 AND org_id=$2 AND verified=$3",
 			domain,
 			orgIdent.id,
 			true,
@@ -8329,7 +8330,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 		})
 
 		huma.Delete(api, "/v1/domains/{domain}", func(ctx context.Context, input *struct {
-			Domain string `path:"domain" example:"1" doc:"Domain ID or name" minLength:"1" maxLength:"253"`
+			Domain string `path:"domain" example:"1" doc:"Domain ID or FQDN" minLength:"1" maxLength:"253"`
 		},
 		) (*struct{}, error) {
 			logger := zlog.Ctx(ctx)
@@ -8366,7 +8367,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 			func(ctx context.Context, input *struct {
 				Org  string `query:"org" example:"1" doc:"Organization ID or name" minLength:"1" maxLength:"63"`
 				Body struct {
-					Name string `json:"name" example:"example.com" doc:"Domain name" minLength:"1" maxLength:"253" pattern:"^[a-z]([-.a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS name"`
+					FQDN string `json:"fqdn" example:"example.com" doc:"Domain FQDN" minLength:"1" maxLength:"253" pattern:"^[a-z]([-.a-z0-9]*[a-z0-9])?$" patternDescription:"valid DNS name"`
 				}
 			},
 			) (*orgDomainOutput, error) {
@@ -8375,7 +8376,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 				// The regex used above is not really a good
 				// filter for valid domain names, do some extra
 				// validation
-				_, ok := dns.IsDomainName(input.Body.Name)
+				_, ok := dns.IsDomainName(input.Body.FQDN)
 				if !ok {
 					return nil, huma.Error422UnprocessableEntity("the DNS name is not valid")
 				}
@@ -8385,7 +8386,7 @@ func setupHumaAPI(router chi.Router, dbc *dbConn, argon2Mutex *sync.Mutex, login
 					return nil, errors.New("unable to read auth data from domains POST handler")
 				}
 
-				domain, err := insertDomain(ctx, logger, dbc, input.Body.Name, &input.Org, ad)
+				domain, err := insertDomain(ctx, logger, dbc, input.Body.FQDN, &input.Org, ad)
 				if err != nil {
 					switch {
 					case errors.Is(err, cdnerrors.ErrForbidden):
@@ -10026,18 +10027,18 @@ func getSessionStore(ctx context.Context, logger zerolog.Logger, dbPool *pgxpool
 
 type domainVerifyData struct {
 	ID                pgtype.UUID
-	Name              string
+	FQDN              string
 	VerificationToken string
 }
 
 func verifyDomain(ctx context.Context, dbPool *pgxpool.Pool, logger zerolog.Logger, resolverAddress string, domainData domainVerifyData, udpClient *dns.Client, tcpClient *dns.Client) error {
-	logger.Info().Str("name", domainData.Name).Msg("found unverified domain name")
+	logger.Info().Str("fqdn", domainData.FQDN).Msg("found unverified domain")
 	m := new(dns.Msg)
-	m.SetQuestion(dns.Fqdn(domainData.Name), dns.TypeTXT)
+	m.SetQuestion(dns.Fqdn(domainData.FQDN), dns.TypeTXT)
 	m.SetEdns0(4096, false)
 	in, rtt, err := udpClient.Exchange(m, resolverAddress)
 	if err != nil {
-		logger.Err(err).Dur("rtt", rtt).Str("name", domainData.Name).Msg("error looking up unverified domain via UDP")
+		logger.Err(err).Dur("rtt", rtt).Str("fqdn", domainData.FQDN).Msg("error looking up unverified domain via UDP")
 		return err
 	}
 
@@ -10045,13 +10046,13 @@ func verifyDomain(ctx context.Context, dbPool *pgxpool.Pool, logger zerolog.Logg
 		logger.Error().Dur("rtt", rtt).Msg("udp query was truncated, retrying over TCP")
 		in, rtt, err = tcpClient.Exchange(m, resolverAddress)
 		if err != nil {
-			logger.Err(err).Dur("rtt", rtt).Str("name", domainData.Name).Msg("error looking up unverified domain via TCP")
+			logger.Err(err).Dur("rtt", rtt).Str("fqdn", domainData.FQDN).Msg("error looking up unverified domain via TCP")
 			return err
 		}
 	}
 
 	if in.Rcode != dns.RcodeSuccess {
-		logger.Error().Str("name", domainData.Name).Str("rcode", dns.RcodeToString[in.Rcode]).Msg("unsuccessful query rcode")
+		logger.Error().Str("fqdn", domainData.FQDN).Str("rcode", dns.RcodeToString[in.Rcode]).Msg("unsuccessful query rcode")
 		return fmt.Errorf("unsuccessful query code")
 	}
 
@@ -10062,7 +10063,7 @@ func verifyDomain(ctx context.Context, dbPool *pgxpool.Pool, logger zerolog.Logg
 			if val, ok := dns.TypeToString[answer.Header().Rrtype]; ok {
 				rrType = val
 			}
-			logger.Error().Str("name", domainData.Name).Str("rr_type", rrType).Msg("unable to parse entry in TXT answer section as TXT record")
+			logger.Error().Str("fqdn", domainData.FQDN).Str("rr_type", rrType).Msg("unable to parse entry in TXT answer section as TXT record")
 			// Keep looking at any additional answers since our record might still be in there
 			continue
 		}
@@ -10094,10 +10095,10 @@ func verifyDomain(ctx context.Context, dbPool *pgxpool.Pool, logger zerolog.Logg
 			if parts[1] == domainData.VerificationToken {
 				_, err := dbPool.Exec(ctx, "UPDATE domains SET verified=true WHERE id=$1", domainData.ID)
 				if err != nil {
-					logger.Err(err).Str("id", domainData.ID.String()).Str("name", domainData.Name).Msg("unable to update verified status for domain")
+					logger.Err(err).Str("id", domainData.ID.String()).Str("fqdn", domainData.FQDN).Msg("unable to update verified status for domain")
 					return fmt.Errorf("unable to update database: %w", err)
 				}
-				logger.Info().Str("id", domainData.ID.String()).Str("name", domainData.Name).Msg("successfully verified domain")
+				logger.Info().Str("id", domainData.ID.String()).Str("fqdn", domainData.FQDN).Msg("successfully verified domain")
 				// We are done
 				return nil
 			}
@@ -10113,10 +10114,12 @@ func domainVerifier(ctx context.Context, wg *sync.WaitGroup, logger zerolog.Logg
 	udpClient := &dns.Client{}
 	tcpClient := &dns.Client{Net: "tcp"}
 
+	tickCh := time.Tick(verifyInterval)
+
 	for {
 		select {
-		case <-time.Tick(verifyInterval):
-			rows, err := dbPool.Query(ctx, "SELECT id, name, verification_token FROM domains WHERE verified=false")
+		case <-tickCh:
+			rows, err := dbPool.Query(ctx, "SELECT id, fqdn, verification_token FROM domains WHERE verified=false")
 			if err != nil {
 				logger.Err(err).Msg("lookup of unverified domains failed")
 				continue

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -149,14 +149,14 @@ func populateTestData(dbPool *pgxpool.Pool, encryptedSessionKey bool) error {
 		"INSERT INTO roles (id, name) VALUES ('00000005-0000-0000-0000-000000000003', 'node')",
 
 		// Domains
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000001', '00000002-0000-0000-0000-000000000001', 'example.se', true, 'token1')",
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000002', '00000002-0000-0000-0000-000000000001', 'example.com', true, 'token2')",
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000003', '00000002-0000-0000-0000-000000000001', 'example.nu', false, 'token2')",
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000004', '00000002-0000-0000-0000-000000000001', 'example-delete-1.se', true, 'token-del-1')",
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000005', '00000002-0000-0000-0000-000000000001', 'example-delete-2.se', true, 'token2-del-2')",
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000006', '00000002-0000-0000-0000-000000000001', 'example-delete-3.se', false, 'token2-del-3')",
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000007', '00000002-0000-0000-0000-000000000001', 'example-delete-4.se', false, 'token2-del-4')",
-		"INSERT INTO domains (id, org_id, name, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000008', '00000002-0000-0000-0000-000000000001', 'example-delete-5.se', false, 'token2-del-5')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000001', '00000002-0000-0000-0000-000000000001', 'example.se', true, 'token1')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000002', '00000002-0000-0000-0000-000000000001', 'example.com', true, 'token2')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000003', '00000002-0000-0000-0000-000000000001', 'example.nu', false, 'token2')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000004', '00000002-0000-0000-0000-000000000001', 'example-delete-1.se', true, 'token-del-1')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000005', '00000002-0000-0000-0000-000000000001', 'example-delete-2.se', true, 'token2-del-2')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000006', '00000002-0000-0000-0000-000000000001', 'example-delete-3.se', false, 'token2-del-3')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000007', '00000002-0000-0000-0000-000000000001', 'example-delete-4.se', false, 'token2-del-4')",
+		"INSERT INTO domains (id, org_id, fqdn, verified, verification_token) VALUES ('00000015-0000-0000-0000-000000000008', '00000002-0000-0000-0000-000000000001', 'example-delete-5.se', false, 'token2-del-5')",
 
 		// Service domain mappings (only valid if the domains-entry is verified=true)
 		// org1: www.example.se
@@ -4233,9 +4233,9 @@ func TestPostDomains(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
 			newDomain := struct {
-				Name string `json:"name"`
+				FQDN string `json:"fqdn"`
 			}{
-				Name: test.newDomain,
+				FQDN: test.newDomain,
 			}
 
 			b, err := json.Marshal(newDomain)


### PR DESCRIPTION
Rename domains.name column to domains.fqdn

Every other entity uses a `name` column validated by is_valid_name()
(DNS label format), but domains store FQDNs validated differently.
The shared column name created ambiguity — domain.Name looked like it
followed the same rules as org.Name or service.Name when it did not.

Rename to `fqdn` across all layers: DB column/constraint/index (new
migration 00007), Go types, SQL queries, API JSON fields, console
form fields, templ templates, and tests. Break domainIdentifier out
of resourceIdentifier so it has its own `fqdn` field instead of
overloading the shared `name` field.

Breaking API change: JSON field "name" becomes "fqdn" in domain
request/response bodies.

Also move the time.Tick() call in domainVerifier outside the select
loop so the channel is created once instead of on every iteration.