### PR TITLE
Add missing rename of constraint and index

### DIFF
--- a/pkg/migrations/files/00005_rename_user_name_to_display_name.sql
+++ b/pkg/migrations/files/00005_rename_user_name_to_display_name.sql
@@ -1,3 +1,5 @@
 -- +goose up
 ALTER TABLE users RENAME COLUMN name TO display_name;
 ALTER TABLE users RENAME CONSTRAINT non_empty_name TO non_empty_display_name;
+ALTER TABLE users RENAME CONSTRAINT users_name_not_null TO users_display_name_not_null;
+ALTER INDEX users_name_key RENAME TO users_display_name_key;


### PR DESCRIPTION
This was missed when renaming the "name" column to "display_name" in the users table.