### PR TITLE
Make Init() run migrations with retries

### DIFF
--- a/cmd/up.go
+++ b/cmd/up.go
@@ -11,7 +11,7 @@ var upCmd = &cobra.Command{
 	Use:   "up",
 	Short: "Migrate to latest version",
 	Long:  `Migrate SQL DB to latest version`,
-	RunE: func(_ *cobra.Command, _ []string) error {
+	RunE: func(cmd *cobra.Command, _ []string) error {
 		conf, err := config.GetConfig(localViper)
 		if err != nil {
 			return err
@@ -22,7 +22,7 @@ var upCmd = &cobra.Command{
 			return err
 		}
 
-		err = migrations.Up(cdnLogger, pgConfig)
+		err = migrations.Up(cmd.Context(), cdnLogger, pgConfig)
 		if err != nil {
 			return err
 		}

--- a/pkg/managerutils/managerutils.go
+++ b/pkg/managerutils/managerutils.go
@@ -1,0 +1,64 @@
+package managerutils
+
+import (
+	"context"
+	"fmt"
+	mrand "math/rand/v2"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func RetryWithBackoff(ctx context.Context, logger zerolog.Logger, sleepBase time.Duration, sleepCap time.Duration, attempts int, description string, operation func(context.Context) error) error {
+	var err error
+
+	if sleepBase <= 0 {
+		return fmt.Errorf("sleepBase must be larger than 0")
+	}
+
+	if sleepCap < sleepBase {
+		return fmt.Errorf("sleepCap must be equal to or larger than sleepBase")
+	}
+
+	if attempts <= 0 {
+		return fmt.Errorf("attempts must be larger than 0")
+	}
+
+	for attempt := range attempts {
+		err = operation(ctx)
+		if err == nil {
+			if attempt > 0 {
+				logger.Info().Int("attempt", attempt+1).Msgf("retryWithBackoff: operation '%s' succeeded after retries", description)
+			}
+			break
+		}
+
+		if attempt < attempts-1 {
+			// Exponential backoff with saturating multiply: if the
+			// shift exceeds sleepCap/sleepBase, skip the
+			// calculation and fall back to sleepCap to avoid
+			// signed overflow.
+			sleepDuration := sleepCap
+			if shift := time.Duration(1) << attempt; shift > 0 && shift <= sleepCap/sleepBase {
+				sleepDuration = sleepBase * shift
+			}
+			// Add jitter (guard against Int64N(0) panic when sleepDuration/2 rounds to 0, e.g. when sleepBase is set to 1ns)
+			if half := sleepDuration / 2; half > 0 {
+				sleepDuration = half + time.Duration(mrand.Int64N(int64(half))) // #nosec G404 -- no need for cryptographically secure randomness for backoff timer
+			}
+			logger.Err(err).Msgf("retryWithBackoff: operation '%s' failed, sleeping for %s", description, sleepDuration)
+			select {
+			case <-ctx.Done():
+				return fmt.Errorf("retryWithBackoff: context cancelled while waiting for '%s': %w", description, ctx.Err())
+			case <-time.After(sleepDuration):
+			}
+		} else {
+			logger.Err(err).Msgf("retryWithBackoff: hit retry limit, giving up on '%s'", description)
+		}
+	}
+	if err != nil {
+		return fmt.Errorf("retryWithBackoff: '%s' failed after %d attempts: %w", description, attempts, err)
+	}
+
+	return nil
+}

--- a/pkg/managerutils/managerutils_test.go
+++ b/pkg/managerutils/managerutils_test.go
@@ -1,0 +1,113 @@
+package managerutils
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/rs/zerolog"
+)
+
+func TestRetryWithBackoff(t *testing.T) {
+	errAllFailed := errors.New("all failed")
+
+	logger := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Caller().Logger()
+
+	tests := []struct {
+		description string
+		sleepBase   time.Duration
+		sleepCap    time.Duration
+		attempts    int
+		operation   func(context.Context) error
+		err         error
+		cancel      bool
+	}{
+		{
+			description: "successful first attempt",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func(context.Context) error {
+				return nil
+			},
+			err:    nil,
+			cancel: false,
+		},
+		{
+			description: "failed first attempt with 1ns sleepBase (sleepDuration/2 rounds to 0)",
+			sleepBase:   time.Nanosecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func() func(context.Context) error {
+				attemptCounter := 0
+				return func(context.Context) error {
+					logger.Info().Int("attempt_counter", attemptCounter).Msg("trying attempt")
+					if attemptCounter > 0 {
+						return nil
+					}
+					attemptCounter++
+					return errors.New("first attempt")
+				}
+			}(),
+			err:    nil,
+			cancel: false,
+		},
+		{
+			description: "all attempts failed",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func(context.Context) error {
+				return errAllFailed
+			},
+			err:    errAllFailed,
+			cancel: false,
+		},
+		{
+			description: "success after retry",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func() func(context.Context) error {
+				attemptCounter := 0
+				return func(context.Context) error {
+					logger.Info().Int("attempt_counter", attemptCounter).Msg("trying attempt")
+					if attemptCounter > 0 {
+						return nil
+					}
+					attemptCounter++
+					return errors.New("first attempt")
+				}
+			}(),
+			err:    nil,
+			cancel: false,
+		},
+		{
+			description: "failed with cancelled context",
+			sleepBase:   time.Millisecond * 1,
+			sleepCap:    time.Millisecond * 10,
+			attempts:    3,
+			operation: func(context.Context) error {
+				return errors.New("we expect to exit early due to context being cancelled")
+			},
+			err:    context.Canceled,
+			cancel: true,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			if test.cancel {
+				cancel()
+			}
+			err := RetryWithBackoff(ctx, logger, test.sleepBase, test.sleepCap, test.attempts, test.description, test.operation)
+			if !errors.Is(err, test.err) {
+				t.Fatalf("wanted err to be: %#v, got: %#v", test.err, err)
+			}
+		})
+	}
+}

--- a/pkg/migrations/migrations.go
+++ b/pkg/migrations/migrations.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"embed"
 	"fmt"
+	"time"
 
+	"github.com/SUNET/sunet-cdn-manager/pkg/managerutils"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/jackc/pgx/v5/stdlib"
 	"github.com/pressly/goose/v3"
@@ -29,24 +31,38 @@ func (gl gooseLogger) Printf(format string, v ...any) {
 //go:embed files/*.sql
 var embedMigrations embed.FS
 
-func Up(logger zerolog.Logger, pgConfig *pgxpool.Config) error {
+func Up(ctx context.Context, logger zerolog.Logger, pgConfig *pgxpool.Config) error {
 	gl := gooseLogger{logger: logger}
 	goose.SetLogger(gl)
 	goose.SetBaseFS(embedMigrations)
 
-	dbPool, err := pgxpool.NewWithConfig(context.Background(), pgConfig)
+	dbPool, err := pgxpool.NewWithConfig(ctx, pgConfig)
 	if err != nil {
 		return fmt.Errorf("unable to create database pool: %w", err)
 	}
 	defer dbPool.Close()
 
+	logger.Info().Msg("checking DB connection for migrations")
+	err = managerutils.RetryWithBackoff(
+		ctx,
+		logger,
+		time.Second*1,
+		time.Second*30,
+		10,
+		"ping DB for migration",
+		dbPool.Ping,
+	)
+	if err != nil {
+		return fmt.Errorf("pinging database connection for migrations failed: %w", err)
+	}
+
 	if err := goose.SetDialect("postgres"); err != nil {
-		return fmt.Errorf("unable to goose.SetDialect()")
+		return fmt.Errorf("unable to goose.SetDialect(): %w", err)
 	}
 
 	db := stdlib.OpenDBFromPool(dbPool)
 
-	if err := goose.Up(db, "files"); err != nil {
+	if err := goose.UpContext(ctx, db, "files"); err != nil {
 		return err
 	}
 

--- a/pkg/migrations/migrations_test.go
+++ b/pkg/migrations/migrations_test.go
@@ -66,12 +66,11 @@ func TestUpMigrations(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		err := Up(logger, pgConfig)
-		if err != nil {
-			t.Fatal(err)
-		}
-		if err != nil {
-			t.Fatalf("%s: up call failed: %s", test.description, err)
-		}
+		t.Run(test.description, func(t *testing.T) {
+			err := Up(context.Background(), logger, pgConfig)
+			if err != nil {
+				t.Fatalf("up call failed: %s", err)
+			}
+		})
 	}
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -18,7 +18,6 @@ import (
 	"io"
 	"log"
 	"math/big"
-	mrand "math/rand/v2"
 	"net/http"
 	"net/netip"
 	"net/url"
@@ -38,6 +37,7 @@ import (
 	"github.com/SUNET/sunet-cdn-manager/pkg/cdntypes"
 	"github.com/SUNET/sunet-cdn-manager/pkg/components"
 	"github.com/SUNET/sunet-cdn-manager/pkg/config"
+	"github.com/SUNET/sunet-cdn-manager/pkg/managerutils"
 	"github.com/SUNET/sunet-cdn-manager/pkg/migrations"
 	"github.com/a-h/templ"
 	"github.com/caddyserver/certmagic"
@@ -9843,13 +9843,13 @@ func Init(logger zerolog.Logger, pgConfig *pgxpool.Config, encryptedSessionKey b
 		return InitUser{}, fmt.Errorf("password too short, must be at least %d characters", minPasswordLen)
 	}
 
-	err := migrations.Up(logger, pgConfig)
+	initCtx, initCancel := context.WithTimeout(context.Background(), 300*time.Second)
+	defer initCancel()
+
+	err := migrations.Up(initCtx, logger, pgConfig)
 	if err != nil {
 		return InitUser{}, fmt.Errorf("unable to run migrations: %w", err)
 	}
-
-	initCtx, initCancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer initCancel()
 
 	dbPool, err := pgxpool.NewWithConfig(initCtx, pgConfig)
 	if err != nil {
@@ -10267,52 +10267,6 @@ func (dbc *dbConn) detachedContextWithDuration(parent context.Context, timeout t
 	return context.WithTimeout(context.WithoutCancel(parent), timeout) // #nosec G118 -- caller is responsible for cancelling the context
 }
 
-func retryWithBackoff(ctx context.Context, logger zerolog.Logger, sleepBase time.Duration, sleepCap time.Duration, attempts int, description string, operation func(context.Context) error) error {
-	var err error
-
-	if sleepBase <= 0 {
-		return fmt.Errorf("sleepBase must be larger than 0")
-	}
-
-	if sleepCap < sleepBase {
-		return fmt.Errorf("sleepCap must be equal to or larger than sleepBase")
-	}
-
-	if attempts <= 0 {
-		return fmt.Errorf("attempts must be larger than 0")
-	}
-
-	for attempt := range attempts {
-		err = operation(ctx)
-		if err == nil {
-			if attempt > 0 {
-				logger.Info().Int("attempt", attempt+1).Msgf("retryWithBackoff: operation '%s' succeeded after retries", description)
-			}
-			break
-		}
-
-		if attempt < attempts-1 {
-			// Exponential backoff
-			sleepDuration := min(sleepCap, sleepBase*(1<<attempt))
-			// Add jitter
-			sleepDuration = sleepDuration/2 + time.Duration(mrand.Int64N(int64(sleepDuration/2))) // #nosec G404 -- no need for cryptographically secure randomness for backoff timer
-			logger.Err(err).Msgf("retryWithBackoff: operation '%s' failed, sleeping for %s", description, sleepDuration)
-			select {
-			case <-ctx.Done():
-				return fmt.Errorf("retryWithBackoff: context cancelled while waiting for '%s': %w", description, ctx.Err())
-			case <-time.After(sleepDuration):
-			}
-		} else {
-			logger.Err(err).Msgf("retryWithBackoff: hit retry limit, giving up on '%s'", description)
-		}
-	}
-	if err != nil {
-		return fmt.Errorf("retryWithBackoff: '%s' failed after %d attempts: %w", description, attempts, err)
-	}
-
-	return nil
-}
-
 func Run(debug bool, localViper *viper.Viper, logger zerolog.Logger, devMode bool, shutdownDelay time.Duration, disableDomainVerification bool, disableAcme bool, tlsCertFile string, tlsKeyFile string) error {
 	if debug {
 		logger = logger.Level(zerolog.DebugLevel)
@@ -10349,7 +10303,7 @@ func Run(debug bool, localViper *viper.Viper, logger zerolog.Logger, devMode boo
 	defer dbPool.Close()
 
 	logger.Info().Msg("checking DB connection")
-	err = retryWithBackoff(
+	err = managerutils.RetryWithBackoff(
 		runCtx,
 		logger,
 		time.Second*1,
@@ -10391,7 +10345,7 @@ func Run(debug bool, localViper *viper.Viper, logger zerolog.Logger, devMode boo
 	providerCtx := oidc.ClientContext(runCtx, client)
 	logger.Info().Msg("setting up OIDC provider")
 	var provider *oidc.Provider
-	err = retryWithBackoff(
+	err = managerutils.RetryWithBackoff(
 		providerCtx,
 		logger,
 		time.Second*1,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -499,7 +499,7 @@ func initDatabase(ctx context.Context, t *testing.T, logger zerolog.Logger, encr
 		return nil, fmt.Errorf("unable to create database pool: %w", err)
 	}
 
-	err = migrations.Up(logger, pgConfig)
+	err = migrations.Up(ctx, logger, pgConfig)
 	if err != nil {
 		dbPool.Close()
 		return nil, err
@@ -7851,90 +7851,6 @@ func TestAuthChallenge(t *testing.T) {
 	challenge := authChallenge("Basic", "test realm")
 	if challenge != expectedChallenge {
 		t.Fatalf("unexpected challenge string, want '%s', have: '%s'", expectedChallenge, challenge)
-	}
-}
-
-func TestRetryWithBackoff(t *testing.T) {
-	errAllFailed := errors.New("all failed")
-
-	logger := zerolog.New(zerolog.NewTestWriter(t)).With().Timestamp().Caller().Logger()
-
-	tests := []struct {
-		description string
-		sleepBase   time.Duration
-		sleepCap    time.Duration
-		attempts    int
-		operation   func(context.Context) error
-		err         error
-		cancel      bool
-	}{
-		{
-			description: "successful first attempt",
-			sleepBase:   time.Millisecond * 1,
-			sleepCap:    time.Millisecond * 10,
-			attempts:    3,
-			operation: func(context.Context) error {
-				return nil
-			},
-			err:    nil,
-			cancel: false,
-		},
-		{
-			description: "all attempts failed",
-			sleepBase:   time.Millisecond * 1,
-			sleepCap:    time.Millisecond * 10,
-			attempts:    3,
-			operation: func(context.Context) error {
-				return errAllFailed
-			},
-			err:    errAllFailed,
-			cancel: false,
-		},
-		{
-			description: "success after retry",
-			sleepBase:   time.Millisecond * 1,
-			sleepCap:    time.Millisecond * 10,
-			attempts:    3,
-			operation: func() func(context.Context) error {
-				attemptCounter := 0
-				return func(context.Context) error {
-					logger.Info().Int("attempt_counter", attemptCounter).Msg("trying attempt")
-					if attemptCounter > 0 {
-						return nil
-					}
-					attemptCounter++
-					return errors.New("first attempt")
-				}
-			}(),
-			err:    nil,
-			cancel: false,
-		},
-		{
-			description: "failed with cancelled context",
-			sleepBase:   time.Millisecond * 1,
-			sleepCap:    time.Millisecond * 10,
-			attempts:    3,
-			operation: func(context.Context) error {
-				return errors.New("we expect to exit early due to context being cancelled")
-			},
-			err:    context.Canceled,
-			cancel: true,
-		},
-	}
-
-	for _, test := range tests {
-		t.Run(test.description, func(t *testing.T) {
-			ctx, cancel := context.WithCancel(context.Background())
-			defer cancel()
-
-			if test.cancel {
-				cancel()
-			}
-			err := retryWithBackoff(ctx, logger, test.sleepBase, test.sleepCap, test.attempts, test.description, test.operation)
-			if !errors.Is(err, test.err) {
-				t.Fatalf("wanted err to be: %#v, got: %#v", test.err, err)
-			}
-		})
 	}
 }
 


### PR DESCRIPTION
Since the docker compose file we use starts with calling the "init"
command on every startup to handle DB migrations, lets try reaching the
database with retries just in case the DB is temporarily unavailable
(e.g. both machines have been rebooted at the same time and are in the
process of starting up).

Beacuse the migrations are handled in the separate migrations package create a new
"managerutils" package for holding the RetryWithBackoff() code so we can
use it in both the server and migration packages. Also make it possible to
pass down the initCtx to migrations.Up() so we can get a timeout which
is now also passed on to goose. Finally move tests for the retry code to
the managerutils package. Include fix for panic when sleepBase is
set to 1ns including a new test that triggers it as well as some
additional tweaks.

Also increase initCtx timeout to give the retries time to work.