### PR TITLE
Replace tickCh with time.After()

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10127,11 +10127,9 @@ func domainVerifier(ctx context.Context, wg *sync.WaitGroup, logger zerolog.Logg
 	udpClient := &dns.Client{}
 	tcpClient := &dns.Client{Net: "tcp"}
 
-	tickCh := time.Tick(verifyInterval)
-
 	for {
 		select {
-		case <-tickCh:
+		case <-time.After(verifyInterval):
 			rows, err := dbPool.Query(ctx, "SELECT id, fqdn, verification_token FROM domains WHERE verified=false")
 			if err != nil {
 				logger.Err(err).Msg("lookup of unverified domains failed")


### PR DESCRIPTION
This way we wait for the full verifyInterval on every iteration rather
than possibly rerunning the contained code directly if it took longer
than retryInterval to complete the previous run.

From the docs:
```
Before Go 1.23, this documentation warned that the underlying Timer
would not be recovered by the garbage collector until the timer fired,
and that if efficiency was a concern, code should use NewTimer
instead and call Timer.Stop if the timer is no longer needed. As
of Go 1.23, the garbage collector can recover unreferenced,
unstopped timers. There is no reason to prefer NewTimer when After
will do.
```

So using time.After() like this should be valid since 1.23.