### PR TITLE
DB is_valid_name(): qualify func names

### DIFF
--- a/pkg/migrations/files/00009_is_valid_name_qualified.sql
+++ b/pkg/migrations/files/00009_is_valid_name_qualified.sql
@@ -1,0 +1,23 @@
+-- +goose up
+
+-- Update is_valid_name to make it reference is_valid_dns_label() and
+-- is_not_uuid() qualified with the "cdn" schema. Without this restoring a
+-- pg_dump file fails with errors if you do not also explicitly call
+-- "SET search_path TO cdn;". Example of error seen:
+-- ##########
+-- ERROR:  function is_valid_dns_label(text) does not exist
+-- LINE 1: is_valid_dns_label(name) AND is_not_uuid(name)
+--         ^
+-- HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+-- QUERY:  is_valid_dns_label(name) AND is_not_uuid(name)
+-- CONTEXT:  PL/pgSQL function cdn.is_valid_name(text) line 3 at RETURN
+-- ##########
+-- Related question: https://dba.stackexchange.com/questions/342360/postgresql-pg-dump-fails-to-correctly-pg-restore-due-to-missing-or-erroneous-cu
+-- +goose StatementBegin
+CREATE OR REPLACE FUNCTION is_valid_name(name text)
+RETURNS boolean AS $$
+BEGIN
+  RETURN cdn.is_valid_dns_label(name) AND cdn.is_not_uuid(name);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE STRICT;
+-- +goose StatementEnd

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -54,6 +54,10 @@ const (
 
 	// Constraint name from migration 00006_name_not_uuid.sql
 	pgConstraintValidName = "valid_name"
+
+	// User that connects to the database
+	dbUser     = "cdn"
+	dbPassword = "cdn-password"
 )
 
 var pgt *postgrestest.Server
@@ -66,6 +70,31 @@ func TestMain(m *testing.M) {
 		panic(err)
 	}
 	defer pgt.Cleanup()
+
+	// Make sure our "cdn" user is present in the database server, this
+	// matches the "cdn" schema we create in each test-specific database.
+	pgurl := pgt.DefaultDatabase()
+
+	pgConfig, err := pgxpool.ParseConfig(pgurl)
+	if err != nil {
+		panic(err)
+	}
+
+	// Make sure tests do not hang even if they only have access to a single db connection
+	pgConfig.MaxConns = 1
+
+	dbPool, err := pgxpool.NewWithConfig(ctx, pgConfig)
+	if err != nil {
+		panic(fmt.Errorf("unable to create database pool: %w", err))
+	}
+
+	_, err = dbPool.Exec(ctx, fmt.Sprintf("CREATE USER %s WITH PASSWORD '%s'", dbUser, dbPassword))
+	if err != nil {
+		panic(fmt.Errorf("unable to create common 'cdn' user: %w", err))
+	}
+
+	// Each test opens its own connection
+	dbPool.Close()
 
 	zerolog.CallerMarshalFunc = func(_ uintptr, file string, line int) string {
 		return filepath.Base(file) + ":" + strconv.Itoa(line)
@@ -478,7 +507,9 @@ type testServerInput struct {
 	dbPool              *pgxpool.Pool
 }
 
-func initDatabase(ctx context.Context, t *testing.T, logger zerolog.Logger, encryptedSessionKey bool) (*pgxpool.Pool, error) {
+func getTestDatabaseConfig(ctx context.Context, t *testing.T) (*pgxpool.Config, error) {
+	t.Helper()
+
 	pgurl, err := pgt.CreateDatabase(ctx)
 	if err != nil {
 		return nil, err
@@ -498,11 +529,62 @@ func initDatabase(ctx context.Context, t *testing.T, logger zerolog.Logger, encr
 	if err != nil {
 		return nil, fmt.Errorf("unable to create database pool: %w", err)
 	}
+	defer dbPool.Close()
+
+	// Mimic initial setup done by init-cdn-db.sh on our real database
+	// servers. But instead of creating a "cdn" database we use use the randomized
+	// database that was given to us by pgt.CreateDatabase(). Since the
+	// psql test server is shared between tests it would not work if each
+	// test tried to create its own "cdn" database.
+	//
+	// Because search_path (SHOW search_path;) starts with "$user" by
+	// default this means any tables will be created in that user-specific
+	// SCHEMA by default instead of falling back to "public". This follows
+	// the "secure schema usage pattern" summarized as "Constrain ordinary
+	// users to user-private schemas" from
+	// https://www.postgresql.org/docs/current/ddl-schemas.html#DDL-SCHEMAS-PATTERNS
+	//
+	// "In PostgreSQL 15 and later, the default configuration supports this usage
+	// pattern. In prior versions, or when using a database that has been upgraded
+	// from a prior version, you will need to remove the public CREATE privilege
+	// from the public schema"
+	bootstrapSQLs := []string{
+		fmt.Sprintf("GRANT ALL PRIVILEGES ON DATABASE \"%s\" TO %s", pgConfig.ConnConfig.Database, dbUser),
+		fmt.Sprintf("CREATE SCHEMA %s AUTHORIZATION %s", dbUser, dbUser),
+	}
+
+	for _, bootstrapSQL := range bootstrapSQLs {
+		_, err := dbPool.Exec(ctx, bootstrapSQL)
+		if err != nil {
+			return nil, fmt.Errorf("unable to bootstrap cdn database: %w", err)
+		}
+	}
+
+	// Switch over to the cdn user so the default search_path automatically
+	// inserts things in the "cdn" ($user) schema.
+	pgConfig.ConnConfig.User = dbUser
+	pgConfig.ConnConfig.Password = dbPassword
+
+	return pgConfig, nil
+}
+
+func initDatabase(ctx context.Context, t *testing.T, logger zerolog.Logger, encryptedSessionKey bool) (*pgxpool.Pool, error) {
+	pgConfig, err := getTestDatabaseConfig(ctx, t)
+	if err != nil {
+		return nil, err
+	}
+
+	t.Log(pgConfig.ConnString())
 
 	err = migrations.Up(ctx, logger, pgConfig)
 	if err != nil {
-		dbPool.Close()
 		return nil, err
+	}
+
+	dbPool, err := pgxpool.NewWithConfig(ctx, pgConfig)
+	if err != nil {
+		dbPool.Close()
+		return nil, fmt.Errorf("unable to create database pool for cdn user: %w", err)
 	}
 
 	err = populateTestData(dbPool, encryptedSessionKey)
@@ -670,12 +752,7 @@ func prepareServer(t *testing.T, tsi testServerInput) (*httptest.Server, *pgxpoo
 
 func TestServerInit(t *testing.T) {
 	ctx := context.Background()
-	pgurl, err := pgt.CreateDatabase(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	pgConfig, err := pgxpool.ParseConfig(pgurl)
+	pgConfig, err := getTestDatabaseConfig(ctx, t)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
When trying a pg_dump + psql restore of the "cdn" database I ran into errors stating `ERROR: function is_valid_dns_label(text) does not exist`. The reason for this is that the pg_dump output file contains:
```
SELECT pg_catalog.set_config('search_path', '', false);
```
which clears the search_path, and with no search_path it is not clear what function is referenced. For this reason update `is_valid_name()` to qualify contained function calls in with the "cdn" schema name.

This migration broke the local tests:
```
ERROR: schema "cdn" does not exist (SQLSTATE 3F000)
```

So also update the test code to create the schema (together with a matching "cdn" user) and start interacting with the test databases as that user so the search_path logic is handled the same as in our real DB servers.