### PR TITLE
Cleanup macro indent

### DIFF
--- a/pkg/cdntypes/cdntypes.go
+++ b/pkg/cdntypes/cdntypes.go
@@ -220,51 +220,51 @@ func VCLRequiredMacros() []string {
 const DefaultVCLTemplate = `#SUNET-CDN-MANAGER preamble
 
 sub vcl_recv {
-  #SUNET-CDN-MANAGER vcl_recv
+#SUNET-CDN-MANAGER vcl_recv
 }
 
 sub vcl_pipe {
-  #SUNET-CDN-MANAGER vcl_pipe
+#SUNET-CDN-MANAGER vcl_pipe
 }
 
 sub vcl_pass {
-  #SUNET-CDN-MANAGER vcl_pass
+#SUNET-CDN-MANAGER vcl_pass
 }
 
 sub vcl_hash {
-  #SUNET-CDN-MANAGER vcl_hash
+#SUNET-CDN-MANAGER vcl_hash
 }
 
 sub vcl_purge {
-  #SUNET-CDN-MANAGER vcl_purge
+#SUNET-CDN-MANAGER vcl_purge
 }
 
 sub vcl_miss {
-  #SUNET-CDN-MANAGER vcl_miss
+#SUNET-CDN-MANAGER vcl_miss
 }
 
 sub vcl_hit {
-  #SUNET-CDN-MANAGER vcl_hit
+#SUNET-CDN-MANAGER vcl_hit
 }
 
 sub vcl_deliver {
-  #SUNET-CDN-MANAGER vcl_deliver
+#SUNET-CDN-MANAGER vcl_deliver
 }
 
 sub vcl_synth {
-  #SUNET-CDN-MANAGER vcl_synth
+#SUNET-CDN-MANAGER vcl_synth
 }
 
 sub vcl_backend_fetch {
-  #SUNET-CDN-MANAGER vcl_backend_fetch
+#SUNET-CDN-MANAGER vcl_backend_fetch
 }
 
 sub vcl_backend_response {
-  #SUNET-CDN-MANAGER vcl_backend_response
+#SUNET-CDN-MANAGER vcl_backend_response
 }
 
 sub vcl_backend_error {
-  #SUNET-CDN-MANAGER vcl_backend_error
+#SUNET-CDN-MANAGER vcl_backend_error
 }`
 
 type Domain struct {

--- a/pkg/migrations/files/00008_vcl_template.sql
+++ b/pkg/migrations/files/00008_vcl_template.sql
@@ -5,51 +5,51 @@ ALTER TABLE service_vcls ADD COLUMN vcl_template text;
 UPDATE service_vcls SET vcl_template =
     '#SUNET-CDN-MANAGER preamble' || E'\n' || E'\n' ||
     'sub vcl_recv {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_recv' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_recv' || E'\n' ||
     COALESCE(vcl_recv || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_pipe {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_pipe' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_pipe' || E'\n' ||
     COALESCE(vcl_pipe || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_pass {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_pass' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_pass' || E'\n' ||
     COALESCE(vcl_pass || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_hash {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_hash' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_hash' || E'\n' ||
     COALESCE(vcl_hash || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_purge {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_purge' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_purge' || E'\n' ||
     COALESCE(vcl_purge || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_miss {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_miss' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_miss' || E'\n' ||
     COALESCE(vcl_miss || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_hit {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_hit' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_hit' || E'\n' ||
     COALESCE(vcl_hit || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_deliver {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_deliver' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_deliver' || E'\n' ||
     COALESCE(vcl_deliver || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_synth {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_synth' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_synth' || E'\n' ||
     COALESCE(vcl_synth || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_backend_fetch {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_backend_fetch' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_backend_fetch' || E'\n' ||
     COALESCE(vcl_backend_fetch || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_backend_response {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_backend_response' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_backend_response' || E'\n' ||
     COALESCE(vcl_backend_response || E'\n', '') ||
     '}' || E'\n' || E'\n' ||
     'sub vcl_backend_error {' || E'\n' ||
-    '  #SUNET-CDN-MANAGER vcl_backend_error' || E'\n' ||
+    '#SUNET-CDN-MANAGER vcl_backend_error' || E'\n' ||
     COALESCE(vcl_backend_error || E'\n', '') ||
     '}';
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -7333,9 +7333,9 @@ func generateCompleteVcl(confTemplates configTemplates, originGroups []cdntypes.
 			macroName := strings.TrimSpace(strings.TrimPrefix(trimmed, cdntypes.VCLMacroPrefix))
 			if content, ok := macroContent[macroName]; ok {
 				if content != "" {
-					fmt.Fprintf(&resultBuf, "# begin SUNET-CDN-MANAGER %s\n%s\n  # end SUNET-CDN-MANAGER %s\n", macroName, content, macroName)
+					fmt.Fprintf(&resultBuf, "# begin SUNET-CDN-MANAGER %s\n%s\n# end SUNET-CDN-MANAGER %s\n", macroName, content, macroName)
 				} else {
-					fmt.Fprintf(&resultBuf, "# begin SUNET-CDN-MANAGER %s\n  # end SUNET-CDN-MANAGER %s\n", macroName, macroName)
+					fmt.Fprintf(&resultBuf, "# begin SUNET-CDN-MANAGER %s\n# end SUNET-CDN-MANAGER %s\n", macroName, macroName)
 				}
 				continue
 			}


### PR DESCRIPTION
It makes sense to have macro lines not be indented in the template so the code handling replacement does not need to handle #begin/#end blocks differently at replacement time.

Modify the migration to match, it has not been applied in test/prod yet so we can get away with it as it is.