### PR TITLE
Supply client for jwk cache correctly

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -10266,7 +10266,6 @@ func setupJwkCache(ctx context.Context, logger zerolog.Logger, client *http.Clie
 			),
 		),
 	)
-	options = append(options, httprc.WithHTTPClient(client))
 
 	// First, set up the `jwk.Cache` object. You need to pass it a
 	// `context.Context` object to control the lifecycle of the background fetching goroutine.
@@ -10275,7 +10274,7 @@ func setupJwkCache(ctx context.Context, logger zerolog.Logger, client *http.Clie
 		return nil, fmt.Errorf("unable to create JWK cache: %w", err)
 	}
 
-	if err := jwkCache.Register(ctx, oiConf.JwksURI); err != nil {
+	if err := jwkCache.Register(ctx, oiConf.JwksURI, jwk.WithHTTPClient(jwk.WrapHTTPClientDefaults(client))); err != nil {
 		return nil, fmt.Errorf("failed to register keycloak JWKS: %w", err)
 	}
 


### PR DESCRIPTION
For some reason this no longer worked in local dev where it would error out even with --dev becase the Keycloak certs were not trusted. My guess is this behaviour changed at during some library update.

While here also add jw.WrapHTTPClientDefaults() which seems to be a way to get the same behaviour as default clients when bringing your own.

Error seen before fix when running "make run-dev":
```
"error":"httprc.Resource.Sync: failed to execute HTTP request: Get \"https://keycloak.sunet-cdn.localhost:8443/realms/sunet-cdn-manager/protocol/openid-connect/certs\": tls: failed to verify certificate: x509: “keycloak.sunet-cdn.localhost” certificate is not standards compliant"
```