### PR TITLE
Implement session cookie expiration

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/go-playground/validator/v10 v10.30.2
 	github.com/google/uuid v1.6.0
 	github.com/gorilla/schema v1.4.1
+	github.com/gorilla/securecookie v1.1.2
 	github.com/gorilla/sessions v1.4.0
 	github.com/hashicorp/golang-lru/v2 v2.0.7
 	github.com/jackc/pgx/v5 v5.9.2
@@ -60,7 +61,6 @@ require (
 	github.com/go-playground/universal-translator v0.18.1 // indirect
 	github.com/go-viper/mapstructure/v2 v2.5.0 // indirect
 	github.com/goccy/go-json v0.10.6 // indirect
-	github.com/gorilla/securecookie v1.1.2 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -27,9 +27,11 @@ type Config struct {
 }
 
 type serverSettings struct {
-	URL              string `validate:"required,https_url"`
-	Addr             string `validate:"required"`
-	VCLValidationURL string `mapstructure:"vcl_validation_url" validate:"required"`
+	URL                  string        `validate:"required,https_url"`
+	Addr                 string        `validate:"required"`
+	VCLValidationURL     string        `mapstructure:"vcl_validation_url" validate:"required"`
+	ConsoleSessionMaxAge time.Duration `mapstructure:"console_session_max_age" validate:"required,min=1s"`
+	ConsoleSessionCapAge time.Duration `mapstructure:"console_session_cap_age" validate:"required,min=1s,gtefield=ConsoleSessionMaxAge"`
 }
 
 type dbSettings struct {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -46,6 +46,7 @@ import (
 	"github.com/go-playground/validator/v10"
 	"github.com/google/uuid"
 	"github.com/gorilla/schema"
+	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	lru "github.com/hashicorp/golang-lru/v2"
 	"github.com/jackc/pgx/v5"
@@ -176,6 +177,10 @@ const (
 	// VCL template with URL-encoding expansion up to ~3x plus other
 	// form fields)
 	formMaxSize = 4 * 1024 * 1024
+
+	// Checking for exact error string is not great but securecookie does
+	// not seem to expose better sentinels
+	cookieExpirationError = "securecookie: expired timestamp"
 )
 
 var (
@@ -398,7 +403,8 @@ func rootHandler(w http.ResponseWriter, r *http.Request) {
 }
 
 const (
-	consoleMissingAuthData           = "console: session missing AuthData"
+	consoleMissingAuthData           = "console: request context missing AuthData"
+	consoleMissingSessionData        = "console: request context missing session data"
 	consoleMissingServicePath        = "console: missing service path in URL"
 	consoleMissingOrgPath            = "console: missing org path in URL"
 	consoleMissingOrgParam           = "console: missing org parameter in URL"
@@ -416,21 +422,24 @@ const (
 	consoleCreateServiceRenderErr    = "unable to render create service error page"
 )
 
-func consoleDashboardHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleDashboardHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		if ad.Username == nil {
 			logger.Error().Msg("consoleDashboardHandler: ad.Username is not set")
@@ -625,21 +634,17 @@ func getOrgDashboardData(ctx context.Context, dbc *dbConn, ad cdntypes.AuthData,
 	}, nil
 }
 
-func consoleOrgDashboardHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleOrgDashboardHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
-
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgName := chi.URLParam(r, "org")
 		if orgName == "" {
@@ -737,21 +742,24 @@ func getFlashMessageStrings(flashMessages []any) []string {
 	return flashMessageStrings
 }
 
-func consoleDomainsHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleDomainsHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgName := chi.URLParam(r, "org")
 		if orgName == "" {
@@ -802,21 +810,24 @@ func consoleDomainsHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.
 	}
 }
 
-func consoleDomainDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleDomainDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgParam := chi.URLParam(r, "org")
 		if orgParam == "" {
@@ -913,21 +924,24 @@ func consoleDomainDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 	}
 }
 
-func consoleAPITokensHandler(dbc *dbConn, cookieStore *sessions.CookieStore, tokenURL *url.URL, serverURL *url.URL) http.HandlerFunc {
+func consoleAPITokensHandler(dbc *dbConn, tokenURL *url.URL, serverURL *url.URL) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgName := chi.URLParam(r, "org")
 		if orgName == "" {
@@ -979,21 +993,24 @@ func consoleAPITokensHandler(dbc *dbConn, cookieStore *sessions.CookieStore, tok
 	}
 }
 
-func consoleAPITokenDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore, clientCredAEADs []cipher.AEAD, kccm *keycloakClientManager, tokenURL *url.URL, serverURL *url.URL) http.HandlerFunc {
+func consoleAPITokenDeleteHandler(dbc *dbConn, clientCredAEADs []cipher.AEAD, kccm *keycloakClientManager, tokenURL *url.URL, serverURL *url.URL) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgParam := chi.URLParam(r, "org")
 		if orgParam == "" {
@@ -1108,23 +1125,26 @@ func parseLimitedForm(w http.ResponseWriter, r *http.Request, maxSize int64) err
 	return err
 }
 
-func consoleCreateAPITokenHandler(dbc *dbConn, cookieStore *sessions.CookieStore, clientCredAEAD cipher.AEAD, kccm *keycloakClientManager) http.HandlerFunc {
+func consoleCreateAPITokenHandler(dbc *dbConn, clientCredAEAD cipher.AEAD, kccm *keycloakClientManager) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
 		title := "Add API token"
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgName := chi.URLParam(r, "org")
 		if orgName == "" {
@@ -1269,21 +1289,24 @@ func consoleCreateAPITokenHandler(dbc *dbConn, cookieStore *sessions.CookieStore
 	}
 }
 
-func consoleServiceDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleServiceDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgParam := chi.URLParam(r, "org")
 		if orgParam == "" {
@@ -1401,21 +1424,24 @@ func consoleServiceDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore)
 	}
 }
 
-func consoleServicesHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleServicesHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgName := chi.URLParam(r, "org")
 		if orgName == "" {
@@ -1498,23 +1524,26 @@ func consoleServicesHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 	}
 }
 
-func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCreateDomainHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
 		title := "Add domain"
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgName := chi.URLParam(r, "org")
 		if orgName == "" {
@@ -1650,23 +1679,26 @@ func consoleCreateDomainHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 	}
 }
 
-func consoleCreateServiceHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCreateServiceHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
 		title := "Create service"
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgName := chi.URLParam(r, "org")
 		if orgName == "" {
@@ -1781,21 +1813,17 @@ func consoleCreateServiceHandler(dbc *dbConn, cookieStore *sessions.CookieStore)
 	}
 }
 
-func consoleNewOriginFieldsetHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleNewOriginFieldsetHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
-
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgStr := r.URL.Query().Get("org")
 		if orgStr == "" {
@@ -1878,21 +1906,24 @@ func consoleNewOriginFieldsetHandler(dbc *dbConn, cookieStore *sessions.CookieSt
 	}
 }
 
-func consoleOrgSwitcherHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleOrgSwitcherHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		session := getSession(r, cookieStore)
+		session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
+		if !ok {
+			logger.Error().Msg(consoleMissingSessionData)
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return
+		}
 
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgStr := r.URL.Query().Get("org")
 		if orgStr == "" {
@@ -1957,7 +1988,7 @@ func consoleOrgSwitcherHandler(dbc *dbConn, cookieStore *sessions.CookieStore) h
 	}
 }
 
-func consoleServiceHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleServiceHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
@@ -1978,16 +2009,12 @@ func consoleServiceHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.
 
 		title := "Service"
 
-		session := getSession(r, cookieStore)
-
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		serviceVersions, err := selectServiceVersions(ctx, dbc, ad, serviceName, orgName)
 		if err != nil {
@@ -2024,7 +2051,7 @@ func consoleServiceHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.
 	}
 }
 
-func consoleServiceVersionHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleServiceVersionHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
@@ -2059,16 +2086,12 @@ func consoleServiceVersionHandler(dbc *dbConn, cookieStore *sessions.CookieStore
 
 		title := "Service version"
 
-		session := getSession(r, cookieStore)
-
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		svc, err := getServiceVersionConfig(ctx, dbc, ad, orgName, serviceName, serviceVersion)
 		if err != nil {
@@ -2159,7 +2182,7 @@ func getServiceVersionCloneData(ctx context.Context, tx pgx.Tx, ad cdntypes.Auth
 	return cloneData, nil
 }
 
-func consoleCreateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.CookieStore, vclValidator *vclValidatorClient, confTemplates configTemplates) http.HandlerFunc {
+func consoleCreateServiceVersionHandler(dbc *dbConn, vclValidator *vclValidatorClient, confTemplates configTemplates) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
@@ -2180,16 +2203,12 @@ func consoleCreateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.Cooki
 
 		title := "Create service version"
 
-		session := getSession(r, cookieStore)
-
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		orgIdent, err := validateOrgName(ctx, logger, dbc.dbPool, orgName)
 		if err != nil {
@@ -2332,7 +2351,7 @@ func consoleCreateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.Cooki
 	}
 }
 
-func consoleActivateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleActivateServiceVersionHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
@@ -2381,16 +2400,12 @@ func consoleActivateServiceVersionHandler(dbc *dbConn, cookieStore *sessions.Coo
 
 		title := "Activate service version"
 
-		session := getSession(r, cookieStore)
-
-		adRef, ok := session.Values["ad"]
+		ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 		if !ok {
 			logger.Error().Msg(consoleMissingAuthData)
 			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
-
-		ad := adRef.(cdntypes.AuthData)
 
 		switch r.Method {
 		case http.MethodGet:
@@ -2565,7 +2580,7 @@ type nodeGroupAssignForm struct {
 }
 
 // Endpoint used for console login
-func loginHandler(dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[string, struct{}], cookieStore *sessions.CookieStore) http.HandlerFunc {
+func loginHandler(dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[string, struct{}], cookieStore *sessions.CookieStore, consoleSessionCapAge time.Duration) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
@@ -2573,7 +2588,12 @@ func loginHandler(dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[st
 		case http.MethodGet:
 			q := r.URL.Query()
 			returnTo := q.Get(returnToKey)
-			adRef := authFromSession(logger, cookieStore, r)
+			session := getSession(r, cookieStore)
+			adRef, err := authFromSession(logger, session, consoleSessionCapAge, r, w)
+			if err != nil {
+				// We have already written a failure response to the client, just return
+				return
+			}
 			if adRef != nil {
 				switch returnTo {
 				case "":
@@ -2588,7 +2608,7 @@ func loginHandler(dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[st
 			}
 
 			// No existing login session, show login form
-			err := renderLoginPage(w, r, returnTo, false)
+			err = renderLoginPage(w, r, returnTo, false)
 			if err != nil {
 				logger.Err(err).Msg("unable to render login page")
 				http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
@@ -2654,12 +2674,10 @@ func loginHandler(dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[st
 			}
 
 			session := getSession(r, cookieStore)
-			session.Values["ad"] = ad
 
-			logger.Info().Msg("saving login session")
-			err = session.Save(r, w)
+			logger.Info().Msg("loginHandler: saving login session")
+			err = setSessionAuth(logger, session, ad, r, w)
 			if err != nil {
-				http.Error(w, err.Error(), http.StatusInternalServerError)
 				return
 			}
 
@@ -2740,7 +2758,12 @@ func logoutSession(r *http.Request, cookieStore *sessions.CookieStore) *sessions
 	logger := hlog.FromRequest(r)
 	session, err := cookieStore.Get(r, cookieName)
 	if err != nil {
-		logger.Err(err).Msg("logoutSession: unable to decode existing cookie, using new one")
+		var scErr securecookie.Error
+		if errors.As(err, &scErr) && scErr.IsDecode() && scErr.Error() == cookieExpirationError {
+			logger.Debug().Err(err).Msg("logoutSession: cookie is expired")
+		} else {
+			logger.Err(err).Msg("logoutSession: unable to decode existing cookie")
+		}
 	}
 
 	// Individual sessions can be deleted by setting Options.MaxAge = -1 for that session.
@@ -2753,7 +2776,12 @@ func getSession(r *http.Request, cookieStore *sessions.CookieStore) *sessions.Se
 	logger := hlog.FromRequest(r)
 	session, err := cookieStore.Get(r, cookieName)
 	if err != nil {
-		logger.Err(err).Msg("getSession: unable to decode existing cookie, using new one")
+		var scErr securecookie.Error
+		if errors.As(err, &scErr) && scErr.IsDecode() && scErr.Error() == cookieExpirationError {
+			logger.Debug().Err(err).Msg("getSession: cookie is expired")
+		} else {
+			logger.Err(err).Msg("getSession: unable to decode existing cookie, using new one")
+		}
 	}
 
 	return session
@@ -2921,12 +2949,9 @@ func oauth2CallbackHandler(oauth2HTTPClient *http.Client, cookieStore *sessions.
 			}
 		}
 
-		session.Values["ad"] = ad
-
-		err = session.Save(r, w)
+		logger.Info().Msg("oauth2CallbackHandler: saving login session")
+		err = setSessionAuth(logger, session, ad, r, w)
 		if err != nil {
-			logger.Err(err).Msg("unable to save session")
-			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 			return
 		}
 
@@ -2937,6 +2962,21 @@ func oauth2CallbackHandler(oauth2HTTPClient *http.Client, cookieStore *sessions.
 
 		validatedRedirect(consolePath, w, r, http.StatusFound)
 	}
+}
+
+func setSessionAuth(logger *zerolog.Logger, s *sessions.Session, ad cdntypes.AuthData, r *http.Request, w http.ResponseWriter) error {
+	s.Values["login_at"] = time.Now().Unix()
+
+	s.Values["ad"] = ad
+
+	err := s.Save(r, w)
+	if err != nil {
+		logger.Err(err).Msg("setSessionAuth: unable to save session")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return err
+	}
+
+	return nil
 }
 
 type keycloakClaims struct {
@@ -3106,7 +3146,10 @@ func newArgon2DefaultSettings() argon2Settings {
 	return argon2Settings
 }
 
-type authDataKey struct{}
+type (
+	authDataKey    struct{}
+	sessionDataKey struct{}
+)
 
 const (
 	wwwAuthenticateHeader = "WWW-Authenticate"
@@ -3348,25 +3391,60 @@ const (
 	cookieName = "sunet-cdn-manager"
 )
 
-func authFromSession(logger *zerolog.Logger, cookieStore *sessions.CookieStore, r *http.Request) *cdntypes.AuthData {
-	session := getSession(r, cookieStore)
-
+func authFromSession(logger *zerolog.Logger, session *sessions.Session, consoleSessionCapAge time.Duration, r *http.Request, w http.ResponseWriter) (*cdntypes.AuthData, error) {
 	adInt, ok := session.Values["ad"]
 	if !ok {
-		return nil
+		return nil, nil
+	}
+
+	loginAt, ok := session.Values["login_at"].(int64)
+	var expireReason string
+	if !ok {
+		expireReason = "login_at missing or unexpected type in session"
+	} else if time.Since(time.Unix(loginAt, 0)) > consoleSessionCapAge {
+		expireReason = "session exceeded cap age"
+	}
+	if expireReason != "" {
+		// The user has been logged in for the maximum allowed duration, force re-auth
+		logger.Info().Str("reason", expireReason).Msg("expiring user session")
+		session.Options.MaxAge = -1
+		err := session.Save(r, w)
+		if err != nil {
+			logger.Err(err).Msg("authFromSession: unable to save expired session")
+			http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+			return nil, err
+		}
+		// Redirect to login (or just display the loginform if already at the login handler)
+		return nil, nil
+	}
+
+	// Slide inactivity window by re-saving (MaxAge is reset)
+	// This could lead to duplicate Set-Cookie headers if further handlers
+	// call Save() but as the last header is expected to win it should be
+	// fine.
+	err := session.Save(r, w)
+	if err != nil {
+		logger.Err(err).Msg("authFromSession: unable to slide session window")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return nil, err
 	}
 
 	logger.Info().Msg("using authentication data from session")
 	ad := adInt.(cdntypes.AuthData)
-	return &ad
+	return &ad, nil
 }
 
-func consoleAuthMiddleware(cookieStore *sessions.CookieStore) func(next http.Handler) http.Handler {
+func consoleAuthMiddleware(cookieStore *sessions.CookieStore, consoleSessionCapAge time.Duration) func(next http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			logger := hlog.FromRequest(r)
 
-			adRef := authFromSession(logger, cookieStore, r)
+			session := getSession(r, cookieStore)
+			adRef, err := authFromSession(logger, session, consoleSessionCapAge, r, w)
+			if err != nil {
+				// We have already written a failure response to the client, just return
+				return
+			}
 			if adRef == nil {
 				logger.Info().Msg("consoleAuthMiddleware: redirecting to login page")
 				err := redirectToLoginPage(w, r)
@@ -3379,6 +3457,7 @@ func consoleAuthMiddleware(cookieStore *sessions.CookieStore) func(next http.Han
 			}
 
 			ctx := context.WithValue(r.Context(), authDataKey{}, *adRef)
+			ctx = context.WithValue(ctx, sessionDataKey{}, session)
 
 			next.ServeHTTP(w, r.WithContext(ctx))
 		})
@@ -7636,70 +7715,70 @@ func newChiRouter(conf config.Config, logger zerolog.Logger, dbc *dbConn, argon2
 	router.Route(consolePath, func(r chi.Router) {
 		r.Use(strictFetch.Handler)
 		r.Use(antiCSRF.Handler)
-		r.Use(consoleAuthMiddleware(cookieStore))
-		r.Get("/", consoleDashboardHandler(dbc, cookieStore))
-		r.Get("/org/{org}", consoleOrgDashboardHandler(dbc, cookieStore))
-		r.Get("/org/{org}/domains", consoleDomainsHandler(dbc, cookieStore))
-		r.Delete("/org/{org}/domains/{domain}", consoleDomainDeleteHandler(dbc, cookieStore))
-		r.Get("/org/{org}/create/domain", consoleCreateDomainHandler(dbc, cookieStore))
-		r.Post("/org/{org}/create/domain", consoleCreateDomainHandler(dbc, cookieStore))
-		r.Get("/org/{org}/services", consoleServicesHandler(dbc, cookieStore))
-		r.Get("/org/{org}/services/{service}", consoleServiceHandler(dbc, cookieStore))
-		r.Delete("/org/{org}/services/{service}", consoleServiceDeleteHandler(dbc, cookieStore))
-		r.Get("/org/{org}/create/service", consoleCreateServiceHandler(dbc, cookieStore))
-		r.Post("/org/{org}/create/service", consoleCreateServiceHandler(dbc, cookieStore))
-		r.Get("/org/{org}/services/{service}/{version}", consoleServiceVersionHandler(dbc, cookieStore))
-		r.Get("/org/{org}/create/service/version/{service}", consoleCreateServiceVersionHandler(dbc, cookieStore, vclValidator, confTemplates))
-		r.Post("/org/{org}/create/service/version/{service}", consoleCreateServiceVersionHandler(dbc, cookieStore, vclValidator, confTemplates))
-		r.Get("/org/{org}/services/{service}/{version}/activate", consoleActivateServiceVersionHandler(dbc, cookieStore))
-		r.Post("/org/{org}/services/{service}/{version}/activate", consoleActivateServiceVersionHandler(dbc, cookieStore))
-		r.Get("/org/{org}/api-tokens", consoleAPITokensHandler(dbc, cookieStore, tokenURL, serverURL))
-		r.Delete("/org/{org}/api-tokens/{api-token}", consoleAPITokenDeleteHandler(dbc, cookieStore, clientCredAEADs, kccm, tokenURL, serverURL))
-		r.Get("/org/{org}/create/api-token", consoleCreateAPITokenHandler(dbc, cookieStore, encryptionClientCredAEAD, kccm))
-		r.Post("/org/{org}/create/api-token", consoleCreateAPITokenHandler(dbc, cookieStore, encryptionClientCredAEAD, kccm))
+		r.Use(consoleAuthMiddleware(cookieStore, conf.Server.ConsoleSessionCapAge))
+		r.Get("/", consoleDashboardHandler(dbc))
+		r.Get("/org/{org}", consoleOrgDashboardHandler(dbc))
+		r.Get("/org/{org}/domains", consoleDomainsHandler(dbc))
+		r.Delete("/org/{org}/domains/{domain}", consoleDomainDeleteHandler(dbc))
+		r.Get("/org/{org}/create/domain", consoleCreateDomainHandler(dbc))
+		r.Post("/org/{org}/create/domain", consoleCreateDomainHandler(dbc))
+		r.Get("/org/{org}/services", consoleServicesHandler(dbc))
+		r.Get("/org/{org}/services/{service}", consoleServiceHandler(dbc))
+		r.Delete("/org/{org}/services/{service}", consoleServiceDeleteHandler(dbc))
+		r.Get("/org/{org}/create/service", consoleCreateServiceHandler(dbc))
+		r.Post("/org/{org}/create/service", consoleCreateServiceHandler(dbc))
+		r.Get("/org/{org}/services/{service}/{version}", consoleServiceVersionHandler(dbc))
+		r.Get("/org/{org}/create/service/version/{service}", consoleCreateServiceVersionHandler(dbc, vclValidator, confTemplates))
+		r.Post("/org/{org}/create/service/version/{service}", consoleCreateServiceVersionHandler(dbc, vclValidator, confTemplates))
+		r.Get("/org/{org}/services/{service}/{version}/activate", consoleActivateServiceVersionHandler(dbc))
+		r.Post("/org/{org}/services/{service}/{version}/activate", consoleActivateServiceVersionHandler(dbc))
+		r.Get("/org/{org}/api-tokens", consoleAPITokensHandler(dbc, tokenURL, serverURL))
+		r.Delete("/org/{org}/api-tokens/{api-token}", consoleAPITokenDeleteHandler(dbc, clientCredAEADs, kccm, tokenURL, serverURL))
+		r.Get("/org/{org}/create/api-token", consoleCreateAPITokenHandler(dbc, encryptionClientCredAEAD, kccm))
+		r.Post("/org/{org}/create/api-token", consoleCreateAPITokenHandler(dbc, encryptionClientCredAEAD, kccm))
 		// htmx helpers
-		r.Get("/new-origin-fieldset", consoleNewOriginFieldsetHandler(dbc, cookieStore))
-		r.Get("/org-switcher", consoleOrgSwitcherHandler(dbc, cookieStore))
+		r.Get("/new-origin-fieldset", consoleNewOriginFieldsetHandler(dbc))
+		r.Get("/org-switcher", consoleOrgSwitcherHandler(dbc))
 		// Superuser console routes
-		r.Get("/superuser/orgs", consoleOrgsHandler(dbc, cookieStore))
-		r.Delete("/superuser/orgs/{org}", consoleOrgDeleteHandler(dbc, cookieStore))
-		r.Get("/superuser/create/org", consoleCreateOrgHandler(dbc, cookieStore))
-		r.Post("/superuser/create/org", consoleCreateOrgHandler(dbc, cookieStore))
-		r.Get("/superuser/orgs/{org}/edit", consoleEditOrgHandler(dbc, cookieStore))
-		r.Post("/superuser/orgs/{org}/edit", consoleEditOrgHandler(dbc, cookieStore))
-		r.Get("/superuser/ip-networks", consoleIPNetworksHandler(dbc, cookieStore))
-		r.Delete("/superuser/ip-networks/{networkID}", consoleIPNetworkDeleteHandler(dbc, cookieStore))
-		r.Get("/superuser/create/ip-network", consoleCreateIPNetworkHandler(dbc, cookieStore))
-		r.Post("/superuser/create/ip-network", consoleCreateIPNetworkHandler(dbc, cookieStore))
-		r.Get("/superuser/cache-nodes", consoleCacheNodesHandler(dbc, cookieStore))
-		r.Delete("/superuser/cache-nodes/{cachenode}", consoleCacheNodeDeleteHandler(dbc, cookieStore))
-		r.Get("/superuser/create/cache-node", consoleCreateCacheNodeHandler(dbc, cookieStore))
-		r.Post("/superuser/create/cache-node", consoleCreateCacheNodeHandler(dbc, cookieStore))
-		r.Get("/superuser/cache-nodes/{cachenode}/edit", consoleEditCacheNodeHandler(dbc, cookieStore))
-		r.Post("/superuser/cache-nodes/{cachenode}/edit", consoleEditCacheNodeHandler(dbc, cookieStore))
-		r.Put("/superuser/cache-nodes/{cachenode}/maintenance", consoleCacheNodeMaintenanceHandler(dbc, cookieStore))
-		r.Put("/superuser/cache-nodes/{cachenode}/node-group", consoleCacheNodeGroupHandler(dbc, cookieStore))
-		r.Get("/superuser/l4lb-nodes", consoleL4LBNodesHandler(dbc, cookieStore))
-		r.Delete("/superuser/l4lb-nodes/{l4lbnode}", consoleL4LBNodeDeleteHandler(dbc, cookieStore))
-		r.Get("/superuser/create/l4lb-node", consoleCreateL4LBNodeHandler(dbc, cookieStore))
-		r.Post("/superuser/create/l4lb-node", consoleCreateL4LBNodeHandler(dbc, cookieStore))
-		r.Get("/superuser/l4lb-nodes/{l4lbnode}/edit", consoleEditL4LBNodeHandler(dbc, cookieStore))
-		r.Post("/superuser/l4lb-nodes/{l4lbnode}/edit", consoleEditL4LBNodeHandler(dbc, cookieStore))
-		r.Put("/superuser/l4lb-nodes/{l4lbnode}/maintenance", consoleL4LBNodeMaintenanceHandler(dbc, cookieStore))
-		r.Put("/superuser/l4lb-nodes/{l4lbnode}/node-group", consoleL4LBNodeGroupHandler(dbc, cookieStore))
-		r.Get("/superuser/node-groups", consoleNodeGroupsHandler(dbc, cookieStore))
-		r.Delete("/superuser/node-groups/{nodegroup}", consoleNodeGroupDeleteHandler(dbc, cookieStore))
-		r.Get("/superuser/create/node-group", consoleCreateNodeGroupHandler(dbc, cookieStore))
-		r.Post("/superuser/create/node-group", consoleCreateNodeGroupHandler(dbc, cookieStore))
-		r.Get("/superuser/node-groups/{nodegroup}/edit", consoleEditNodeGroupHandler(dbc, cookieStore))
-		r.Post("/superuser/node-groups/{nodegroup}/edit", consoleEditNodeGroupHandler(dbc, cookieStore))
-		r.Get("/superuser/users", consoleUsersHandler(dbc, cookieStore))
-		r.Delete("/superuser/users/{userID}", consoleUserDeleteHandler(dbc, cookieStore))
-		r.Get("/superuser/create/user", consoleCreateUserHandler(dbc, cookieStore, argon2Mutex))
-		r.Post("/superuser/create/user", consoleCreateUserHandler(dbc, cookieStore, argon2Mutex))
-		r.Get("/superuser/users/{userID}/edit", consoleEditUserHandler(dbc, cookieStore))
-		r.Post("/superuser/users/{userID}/edit", consoleEditUserHandler(dbc, cookieStore))
-		r.Post("/superuser/users/{userID}/reset-password", consoleUserResetPasswordHandler(dbc, cookieStore, argon2Mutex, loginCache))
+		r.Get("/superuser/orgs", consoleOrgsHandler(dbc))
+		r.Delete("/superuser/orgs/{org}", consoleOrgDeleteHandler(dbc))
+		r.Get("/superuser/create/org", consoleCreateOrgHandler(dbc))
+		r.Post("/superuser/create/org", consoleCreateOrgHandler(dbc))
+		r.Get("/superuser/orgs/{org}/edit", consoleEditOrgHandler(dbc))
+		r.Post("/superuser/orgs/{org}/edit", consoleEditOrgHandler(dbc))
+		r.Get("/superuser/ip-networks", consoleIPNetworksHandler(dbc))
+		r.Delete("/superuser/ip-networks/{networkID}", consoleIPNetworkDeleteHandler(dbc))
+		r.Get("/superuser/create/ip-network", consoleCreateIPNetworkHandler(dbc))
+		r.Post("/superuser/create/ip-network", consoleCreateIPNetworkHandler(dbc))
+		r.Get("/superuser/cache-nodes", consoleCacheNodesHandler(dbc))
+		r.Delete("/superuser/cache-nodes/{cachenode}", consoleCacheNodeDeleteHandler(dbc))
+		r.Get("/superuser/create/cache-node", consoleCreateCacheNodeHandler(dbc))
+		r.Post("/superuser/create/cache-node", consoleCreateCacheNodeHandler(dbc))
+		r.Get("/superuser/cache-nodes/{cachenode}/edit", consoleEditCacheNodeHandler(dbc))
+		r.Post("/superuser/cache-nodes/{cachenode}/edit", consoleEditCacheNodeHandler(dbc))
+		r.Put("/superuser/cache-nodes/{cachenode}/maintenance", consoleCacheNodeMaintenanceHandler(dbc))
+		r.Put("/superuser/cache-nodes/{cachenode}/node-group", consoleCacheNodeGroupHandler(dbc))
+		r.Get("/superuser/l4lb-nodes", consoleL4LBNodesHandler(dbc))
+		r.Delete("/superuser/l4lb-nodes/{l4lbnode}", consoleL4LBNodeDeleteHandler(dbc))
+		r.Get("/superuser/create/l4lb-node", consoleCreateL4LBNodeHandler(dbc))
+		r.Post("/superuser/create/l4lb-node", consoleCreateL4LBNodeHandler(dbc))
+		r.Get("/superuser/l4lb-nodes/{l4lbnode}/edit", consoleEditL4LBNodeHandler(dbc))
+		r.Post("/superuser/l4lb-nodes/{l4lbnode}/edit", consoleEditL4LBNodeHandler(dbc))
+		r.Put("/superuser/l4lb-nodes/{l4lbnode}/maintenance", consoleL4LBNodeMaintenanceHandler(dbc))
+		r.Put("/superuser/l4lb-nodes/{l4lbnode}/node-group", consoleL4LBNodeGroupHandler(dbc))
+		r.Get("/superuser/node-groups", consoleNodeGroupsHandler(dbc))
+		r.Delete("/superuser/node-groups/{nodegroup}", consoleNodeGroupDeleteHandler(dbc))
+		r.Get("/superuser/create/node-group", consoleCreateNodeGroupHandler(dbc))
+		r.Post("/superuser/create/node-group", consoleCreateNodeGroupHandler(dbc))
+		r.Get("/superuser/node-groups/{nodegroup}/edit", consoleEditNodeGroupHandler(dbc))
+		r.Post("/superuser/node-groups/{nodegroup}/edit", consoleEditNodeGroupHandler(dbc))
+		r.Get("/superuser/users", consoleUsersHandler(dbc))
+		r.Delete("/superuser/users/{userID}", consoleUserDeleteHandler(dbc))
+		r.Get("/superuser/create/user", consoleCreateUserHandler(dbc, argon2Mutex))
+		r.Post("/superuser/create/user", consoleCreateUserHandler(dbc, argon2Mutex))
+		r.Get("/superuser/users/{userID}/edit", consoleEditUserHandler(dbc))
+		r.Post("/superuser/users/{userID}/edit", consoleEditUserHandler(dbc))
+		r.Post("/superuser/users/{userID}/reset-password", consoleUserResetPasswordHandler(dbc, argon2Mutex, loginCache))
 	})
 
 	oauth2HTTPClient := &http.Client{
@@ -7717,8 +7796,8 @@ func newChiRouter(conf config.Config, logger zerolog.Logger, dbc *dbConn, argon2
 	router.Route("/auth", func(r chi.Router) {
 		r.Use(strictFetch.Handler)
 		r.Use(antiCSRF.Handler)
-		r.Get("/login", loginHandler(dbc, argon2Mutex, loginCache, cookieStore))
-		r.Post("/login", loginHandler(dbc, argon2Mutex, loginCache, cookieStore))
+		r.Get("/login", loginHandler(dbc, argon2Mutex, loginCache, cookieStore, conf.Server.ConsoleSessionCapAge))
+		r.Post("/login", loginHandler(dbc, argon2Mutex, loginCache, cookieStore, conf.Server.ConsoleSessionCapAge))
 		r.Post("/logout", logoutHandler(cookieStore))
 		if provider != nil {
 			idTokenVerifier := provider.Verifier(&oidc.Config{ClientID: conf.OIDC.ClientID})
@@ -10101,7 +10180,7 @@ func getSessionKeys(ctx context.Context, dbPool *pgxpool.Pool) ([]sessionKey, er
 	return sessionKeys, nil
 }
 
-func getSessionStore(ctx context.Context, logger zerolog.Logger, dbPool *pgxpool.Pool) (*sessions.CookieStore, error) {
+func getSessionStore(ctx context.Context, logger zerolog.Logger, dbPool *pgxpool.Pool, consoleSessionMaxAge time.Duration) (*sessions.CookieStore, error) {
 	sessionKeys, err := getSessionKeys(ctx, dbPool)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find session keys in database, make sure the database is initialized via the 'init' command: %w", err)
@@ -10127,6 +10206,18 @@ func getSessionStore(ctx context.Context, logger zerolog.Logger, dbPool *pgxpool
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
 	}
+
+	// This controls how long the cookie will be valid from the last time
+	// Save() was called on it.
+	maxAgeSeconds := int(consoleSessionMaxAge / time.Second)
+	// Make sure we don't accidentally set a 0 MaxAge which makes it long
+	// lived, preferring either 1 or -1
+	if consoleSessionMaxAge > 0 && maxAgeSeconds == 0 {
+		maxAgeSeconds = 1
+	} else if consoleSessionMaxAge < 0 && maxAgeSeconds == 0 {
+		maxAgeSeconds = -1
+	}
+	sessionStore.MaxAge(maxAgeSeconds)
 
 	return sessionStore, nil
 }
@@ -10415,10 +10506,10 @@ func Run(debug bool, localViper *viper.Viper, logger zerolog.Logger, devMode boo
 		return fmt.Errorf("unable to check for roles in the database, is it initialized? (see init command): %w", err)
 	}
 	if !rolesExists {
-		return errors.New("we exepect there to exist at least one role in the database, make sure the database is initialized via the 'init' command")
+		return errors.New("we expect there to exist at least one role in the database, make sure the database is initialized via the 'init' command")
 	}
 
-	cookieStore, err := getSessionStore(runCtx, logger, dbPool)
+	cookieStore, err := getSessionStore(runCtx, logger, dbPool, conf.Server.ConsoleSessionMaxAge)
 	if err != nil {
 		return fmt.Errorf("getSessionStore failed: %w", err)
 	}
@@ -10661,23 +10752,24 @@ func isOrgMember(ad cdntypes.AuthData, orgParam string) bool {
 
 // consoleSuperuserCheck validates that the session user is a superuser.
 // Returns the AuthData and true if ok, or writes a 403 if not superuser or a 500 if auth data is missing, and returns false.
-func consoleSuperuserCheck(w http.ResponseWriter, r *http.Request, cookieStore *sessions.CookieStore) (cdntypes.AuthData, *sessions.Session, bool) {
+func consoleSuperuserCheck(w http.ResponseWriter, r *http.Request) (cdntypes.AuthData, *sessions.Session, bool) {
 	logger := hlog.FromRequest(r)
-	session := getSession(r, cookieStore)
+	ctx := r.Context()
 
-	adRef, ok := session.Values["ad"]
+	ad, ok := ctx.Value(authDataKey{}).(cdntypes.AuthData)
 	if !ok {
-		logger.Error().Msg(consoleMissingAuthData)
+		logger.Error().Msg("consoleSuperuserCheck: unable to read auth data from context")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return cdntypes.AuthData{}, nil, false
 	}
 
-	ad, ok := adRef.(cdntypes.AuthData)
+	session, ok := ctx.Value(sessionDataKey{}).(*sessions.Session)
 	if !ok {
-		logger.Error().Msg("consoleSuperuserCheck: unexpected auth data type in session")
+		logger.Error().Msg("consoleSuperuserCheck: unable to read session data from context")
 		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return cdntypes.AuthData{}, nil, false
 	}
+
 	if !ad.Superuser {
 		http.Error(w, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 		return cdntypes.AuthData{}, nil, false
@@ -10698,12 +10790,12 @@ func sessionSelectedOrg(session *sessions.Session) string {
 	return ""
 }
 
-func consoleOrgsHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleOrgsHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -10735,12 +10827,12 @@ func consoleOrgsHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.Han
 	}
 }
 
-func consoleOrgDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleOrgDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -10794,13 +10886,13 @@ func consoleOrgDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) htt
 	}
 }
 
-func consoleCreateOrgHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCreateOrgHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 		title := "Add organization"
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -10910,12 +11002,12 @@ func consoleCreateOrgHandler(dbc *dbConn, cookieStore *sessions.CookieStore) htt
 	}
 }
 
-func consoleEditOrgHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleEditOrgHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11068,12 +11160,12 @@ func consoleEditOrgHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.
 	}
 }
 
-func consoleCacheNodesHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCacheNodesHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11112,12 +11204,12 @@ func consoleCacheNodesHandler(dbc *dbConn, cookieStore *sessions.CookieStore) ht
 	}
 }
 
-func consoleCacheNodeDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCacheNodeDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11173,13 +11265,13 @@ func consoleCacheNodeDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStor
 	}
 }
 
-func consoleCreateCacheNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCreateCacheNodeHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 		title := "Add cache node"
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11280,12 +11372,12 @@ func consoleCreateCacheNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStor
 	}
 }
 
-func consoleEditCacheNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleEditCacheNodeHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11428,12 +11520,12 @@ func consoleEditCacheNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStore)
 	}
 }
 
-func consoleCacheNodeMaintenanceHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCacheNodeMaintenanceHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11501,12 +11593,12 @@ func consoleCacheNodeMaintenanceHandler(dbc *dbConn, cookieStore *sessions.Cooki
 	}
 }
 
-func consoleCacheNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCacheNodeGroupHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11584,12 +11676,12 @@ func consoleCacheNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStore
 	}
 }
 
-func consoleL4LBNodesHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleL4LBNodesHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11628,12 +11720,12 @@ func consoleL4LBNodesHandler(dbc *dbConn, cookieStore *sessions.CookieStore) htt
 	}
 }
 
-func consoleL4LBNodeDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleL4LBNodeDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11689,13 +11781,13 @@ func consoleL4LBNodeDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore
 	}
 }
 
-func consoleCreateL4LBNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCreateL4LBNodeHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 		title := "Add L4LB node"
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11796,12 +11888,12 @@ func consoleCreateL4LBNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStore
 	}
 }
 
-func consoleEditL4LBNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleEditL4LBNodeHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -11944,12 +12036,12 @@ func consoleEditL4LBNodeHandler(dbc *dbConn, cookieStore *sessions.CookieStore) 
 	}
 }
 
-func consoleL4LBNodeMaintenanceHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleL4LBNodeMaintenanceHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12017,12 +12109,12 @@ func consoleL4LBNodeMaintenanceHandler(dbc *dbConn, cookieStore *sessions.Cookie
 	}
 }
 
-func consoleL4LBNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleL4LBNodeGroupHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12100,12 +12192,12 @@ func consoleL4LBNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStore)
 	}
 }
 
-func consoleNodeGroupsHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleNodeGroupsHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12137,12 +12229,12 @@ func consoleNodeGroupsHandler(dbc *dbConn, cookieStore *sessions.CookieStore) ht
 	}
 }
 
-func consoleNodeGroupDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleNodeGroupDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12198,13 +12290,13 @@ func consoleNodeGroupDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStor
 	}
 }
 
-func consoleCreateNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCreateNodeGroupHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 		title := "Add node group"
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12289,12 +12381,12 @@ func consoleCreateNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStor
 	}
 }
 
-func consoleEditNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleEditNodeGroupHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12410,12 +12502,12 @@ func consoleEditNodeGroupHandler(dbc *dbConn, cookieStore *sessions.CookieStore)
 	}
 }
 
-func consoleIPNetworksHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleIPNetworksHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12475,12 +12567,12 @@ func parseUUIDParam(w http.ResponseWriter, r *http.Request, param string) (pgtyp
 	return id, true
 }
 
-func consoleIPNetworkDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleIPNetworkDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12536,13 +12628,13 @@ func consoleIPNetworkDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStor
 	}
 }
 
-func consoleCreateIPNetworkHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleCreateIPNetworkHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 		title := "Add IP network"
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12641,12 +12733,12 @@ func consoleCreateIPNetworkHandler(dbc *dbConn, cookieStore *sessions.CookieStor
 	}
 }
 
-func consoleUsersHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleUsersHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12678,12 +12770,12 @@ func consoleUsersHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.Ha
 	}
 }
 
-func consoleUserDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleUserDeleteHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12735,13 +12827,13 @@ func consoleUserDeleteHandler(dbc *dbConn, cookieStore *sessions.CookieStore) ht
 	}
 }
 
-func consoleCreateUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore, argon2Mutex *sync.Mutex) http.HandlerFunc {
+func consoleCreateUserHandler(dbc *dbConn, argon2Mutex *sync.Mutex) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 		title := "Add user"
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -12878,12 +12970,12 @@ func consoleCreateUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore, ar
 	}
 }
 
-func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http.HandlerFunc {
+func consoleEditUserHandler(dbc *dbConn) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}
@@ -13050,12 +13142,12 @@ func consoleEditUserHandler(dbc *dbConn, cookieStore *sessions.CookieStore) http
 	}
 }
 
-func consoleUserResetPasswordHandler(dbc *dbConn, cookieStore *sessions.CookieStore, argon2Mutex *sync.Mutex, loginCache *lru.Cache[string, struct{}]) http.HandlerFunc {
+func consoleUserResetPasswordHandler(dbc *dbConn, argon2Mutex *sync.Mutex, loginCache *lru.Cache[string, struct{}]) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		logger := hlog.FromRequest(r)
 		ctx := r.Context()
 
-		ad, session, ok := consoleSuperuserCheck(w, r, cookieStore)
+		ad, session, ok := consoleSuperuserCheck(w, r)
 		if !ok {
 			return
 		}

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -505,14 +505,16 @@ func populateTestData(dbPool *pgxpool.Pool, encryptedSessionKey bool) error {
 }
 
 type testServerInput struct {
-	encryptedSessionKey bool
-	vclValidator        *vclValidatorClient
-	kcClientManager     *keycloakClientManager
-	jwkCache            *jwk.Cache
-	jwtIssuer           string
-	oiConf              openidConfig
-	encryptionPasswords []string
-	dbPool              *pgxpool.Pool
+	encryptedSessionKey  bool
+	vclValidator         *vclValidatorClient
+	kcClientManager      *keycloakClientManager
+	jwkCache             *jwk.Cache
+	jwtIssuer            string
+	oiConf               openidConfig
+	encryptionPasswords  []string
+	dbPool               *pgxpool.Pool
+	consoleSessionMaxAge time.Duration
+	consoleSessionCapAge time.Duration
 }
 
 func getTestDatabaseConfig(ctx context.Context, t *testing.T) (*pgxpool.Config, error) {
@@ -618,7 +620,11 @@ func prepareServer(t *testing.T, tsi testServerInput) (*httptest.Server, *pgxpoo
 		dbPoolCreated = true
 	}
 
-	cookieStore, err := getSessionStore(ctx, logger, tsi.dbPool)
+	if tsi.consoleSessionMaxAge == 0 {
+		tsi.consoleSessionMaxAge = 1 * time.Hour
+	}
+
+	cookieStore, err := getSessionStore(ctx, logger, tsi.dbPool, tsi.consoleSessionMaxAge)
 	if err != nil {
 		if dbPoolCreated {
 			tsi.dbPool.Close()
@@ -732,7 +738,14 @@ func prepareServer(t *testing.T, tsi testServerInput) (*httptest.Server, *pgxpoo
 		t.Fatalf("unable to parse testserver URL: %v", err)
 	}
 
-	router := newChiRouter(config.Config{}, logger, dbc, &argon2Mutex, loginCache, cookieStore, nil, tsi.vclValidator, confTemplates, false, clientCredAEADs, tsi.kcClientManager, &url.URL{}, serverURL)
+	if tsi.consoleSessionCapAge == 0 {
+		tsi.consoleSessionCapAge = 8 * time.Hour
+	}
+
+	conf := config.Config{}
+	conf.Server.ConsoleSessionCapAge = tsi.consoleSessionCapAge
+
+	router := newChiRouter(conf, logger, dbc, &argon2Mutex, loginCache, cookieStore, nil, tsi.vclValidator, confTemplates, false, clientCredAEADs, tsi.kcClientManager, &url.URL{}, serverURL)
 
 	ts.Config.Handler = router
 
@@ -8129,16 +8142,9 @@ func TestConsoleDashboardRedirect(t *testing.T) {
 		}
 	})
 
-	// Verify the redirect only fires once. consoleLogin follows the
-	// full redirect chain (login -> /console -> /console/org/org1)
-	// which sets selectedOrgKey. A subsequent GET /console should
-	// render the superuser dashboard directly (200), not redirect.
+	// Verify the redirect only fires once.
 	t.Run("superuser with org subsequent visit renders dashboard", func(t *testing.T) {
-		client := consoleLogin(t, ts.URL, "admin-with-org", validAdminPassword)
-
-		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
-			return http.ErrUseLastResponse
-		}
+		client, _ := consoleLogin(t, ts.URL, "admin-with-org", validAdminPassword)
 
 		req, err := http.NewRequest("GET", ts.URL+"/console", nil)
 		if err != nil {
@@ -8146,7 +8152,33 @@ func TestConsoleDashboardRedirect(t *testing.T) {
 		}
 		req.Header.Set("Sec-Fetch-Site", "same-origin")
 
+		// This request follows the full redirect chain (login -> /console ->
+		// /console/org/org1) which sets selectedOrgKey. A subsequent GET
+		// /console should render the superuser dashboard directly (200), not
+		// redirect.
 		resp, err := client.Do(req) // #nosec G704
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp.Body.Close()
+
+		if resp.StatusCode != http.StatusOK {
+			t.Fatal("unexpected status code when filling in selectedOrgKey")
+		}
+
+		// Now do the subsequent lookup that should not follow redirects
+		// and verify we directly get a 200
+		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		}
+
+		req, err = http.NewRequest("GET", ts.URL+"/console", nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Set("Sec-Fetch-Site", "same-origin")
+
+		resp, err = client.Do(req) // #nosec G704
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -8161,7 +8193,7 @@ func TestConsoleDashboardRedirect(t *testing.T) {
 	// membership (admin user) gets the generic dashboard (200) with
 	// no redirect, since ad.OrgName is nil.
 	t.Run("superuser without org sees generic dashboard", func(t *testing.T) {
-		client := consoleLogin(t, ts.URL, "admin", validAdminPassword)
+		client, _ := consoleLogin(t, ts.URL, "admin", validAdminPassword)
 
 		client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 			return http.ErrUseLastResponse
@@ -8189,7 +8221,7 @@ func TestConsoleDashboardRedirect(t *testing.T) {
 	// org switcher. After that, GET /console should render the
 	// dashboard (200) and not re-redirect to the org.
 	t.Run("superuser with org can unselect org and stay on generic dashboard", func(t *testing.T) {
-		client := consoleLogin(t, ts.URL, "admin-with-org", validAdminPassword)
+		client, _ := consoleLogin(t, ts.URL, "admin-with-org", validAdminPassword)
 
 		// Use the org switcher to explicitly unselect
 		req, err := http.NewRequest("GET", ts.URL+"/console/org-switcher?org="+url.QueryEscape(cdntypes.OrgNotSelected), nil)
@@ -8266,7 +8298,7 @@ func TestConsoleServicesComponent(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, test.username, test.password)
+			client, _ := consoleLogin(t, ts.URL, test.username, test.password)
 
 			req, err := http.NewRequest("GET", ts.URL+"/console/org/"+test.orgNameOrID+"/services", nil)
 			if err != nil {
@@ -8382,7 +8414,7 @@ func TestConsoleFormLimit(t *testing.T) {
 			defer loginResp.Body.Close()
 
 			if loginResp.StatusCode != test.statusCode {
-				t.Fatalf("unexpected console login status code: %d, expected %d", loginResp.StatusCode, test.statusCode)
+				t.Fatalf("TestConsoleFormLimit: unexpected console login status code: %d, expected %d", loginResp.StatusCode, test.statusCode)
 			}
 		})
 	}
@@ -8823,7 +8855,7 @@ func TestConsoleDeleteErrorRendering(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, test.username, test.password)
+			client, _ := consoleLogin(t, ts.URL, test.username, test.password)
 
 			var reqBody io.Reader
 			if test.formBody != "" {
@@ -8953,7 +8985,7 @@ func TestConsolePhase2ErrorRendering(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, test.username, test.password)
+			client, _ := consoleLogin(t, ts.URL, test.username, test.password)
 
 			req, err := http.NewRequest(test.method, ts.URL+test.path, nil)
 			if err != nil {
@@ -9066,7 +9098,7 @@ func TestGetRoles(t *testing.T) {
 }
 
 // consoleLogin is a helper that performs console login and returns an authenticated client.
-func consoleLogin(t *testing.T, tsURL string, username, password string) *http.Client {
+func consoleLogin(t *testing.T, tsURL string, username, password string) (*http.Client, *http.Cookie) {
 	t.Helper()
 
 	jar, err := cookiejar.New(nil)
@@ -9074,7 +9106,15 @@ func consoleLogin(t *testing.T, tsURL string, username, password string) *http.C
 		t.Fatal(err)
 	}
 
-	client := &http.Client{Jar: jar}
+	client := &http.Client{
+		Jar: jar,
+		// Do not automatically follow redirects so when we inspect the
+		// response cookies below we are sure to inspect the initial
+		// response.
+		CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+	}
 
 	form := url.Values{
 		"username": {username},
@@ -9100,8 +9140,15 @@ func consoleLogin(t *testing.T, tsURL string, username, password string) *http.C
 	}
 	defer loginResp.Body.Close()
 
-	if loginResp.StatusCode != http.StatusOK {
-		t.Fatalf("unexpected console login status code: %d", loginResp.StatusCode)
+	if loginResp.StatusCode != http.StatusFound {
+		t.Fatalf("consoleLogin: unexpected console login status code: %d", loginResp.StatusCode)
+	}
+
+	var sessionCookie *http.Cookie
+	for _, c := range loginResp.Cookies() {
+		if c.Name == cookieName {
+			sessionCookie = c
+		}
 	}
 
 	cookieFound := false
@@ -9115,7 +9162,11 @@ func consoleLogin(t *testing.T, tsURL string, username, password string) *http.C
 		t.Fatal("login failed: session cookie is missing")
 	}
 
-	return client
+	// Make the client follow redirects again so downstream users work as normal clients
+	// client.CheckRedirect = nil
+	client.CheckRedirect = nil
+
+	return client, sessionCookie
 }
 
 func TestConsoleUsersList(t *testing.T) {
@@ -9153,7 +9204,7 @@ func TestConsoleUsersList(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, test.username, test.password)
+			client, _ := consoleLogin(t, ts.URL, test.username, test.password)
 
 			req, err := http.NewRequest("GET", ts.URL+"/console/superuser/users", nil)
 			if err != nil {
@@ -9260,7 +9311,7 @@ func TestConsoleCreateUser(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, "admin", validAdminPassword)
+			client, _ := consoleLogin(t, ts.URL, "admin", validAdminPassword)
 
 			client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -9378,7 +9429,7 @@ func TestConsoleEditUser(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, "admin", validAdminPassword)
+			client, _ := consoleLogin(t, ts.URL, "admin", validAdminPassword)
 
 			client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -9489,7 +9540,7 @@ func TestConsoleDeleteUser(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, "admin", validAdminPassword)
+			client, _ := consoleLogin(t, ts.URL, "admin", validAdminPassword)
 
 			client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -9608,7 +9659,7 @@ func TestConsoleResetPassword(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			client := consoleLogin(t, ts.URL, "admin", validAdminPassword)
+			client, _ := consoleLogin(t, ts.URL, "admin", validAdminPassword)
 
 			client.CheckRedirect = func(_ *http.Request, _ []*http.Request) error {
 				return http.ErrUseLastResponse
@@ -9993,7 +10044,7 @@ func TestConsoleIPNetworks(t *testing.T) {
 	}
 	defer ts.Close()
 
-	client := consoleLogin(t, ts.URL, "admin", validAdminPassword)
+	client, _ := consoleLogin(t, ts.URL, "admin", validAdminPassword)
 
 	t.Run("list page renders", func(t *testing.T) {
 		req, err := http.NewRequest("GET", ts.URL+"/console/superuser/ip-networks", nil)
@@ -10254,4 +10305,126 @@ func TestConsoleIPNetworks(t *testing.T) {
 			t.Fatal("expected flash message confirming deletion")
 		}
 	})
+}
+
+func TestConsoleCookieExpiration(t *testing.T) {
+	tests := []struct {
+		description          string
+		username             string
+		password             string
+		expectedStatus       int
+		consoleSessionMaxAge time.Duration
+		consoleSessionCapAge time.Duration
+		sleepDuration        time.Duration
+		expectedLocation     string
+	}{
+		{
+			description:          "re-auth on expired activity window",
+			username:             "admin",
+			password:             validAdminPassword,
+			expectedStatus:       http.StatusFound,
+			consoleSessionMaxAge: 1 * time.Second,
+			consoleSessionCapAge: 1 * time.Hour,
+			sleepDuration:        2 * time.Second,
+			expectedLocation:     "/auth/login?return_to=%2Fconsole",
+		},
+		{
+			description:          "re-auth on expired cap window",
+			username:             "admin",
+			password:             validAdminPassword,
+			expectedStatus:       http.StatusFound,
+			consoleSessionMaxAge: 1 * time.Hour,
+			consoleSessionCapAge: 1 * time.Second,
+			sleepDuration:        2 * time.Second,
+			expectedLocation:     "/auth/login?return_to=%2Fconsole",
+		},
+		{
+			description:          "valid cookie got MaxAge renewed",
+			username:             "admin",
+			password:             validAdminPassword,
+			expectedStatus:       http.StatusOK,
+			consoleSessionMaxAge: 1 * time.Hour,
+			consoleSessionCapAge: 8 * time.Hour,
+			sleepDuration:        2 * time.Second,
+			expectedLocation:     "",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			ts, dbPool, err := prepareServer(t, testServerInput{consoleSessionMaxAge: test.consoleSessionMaxAge, consoleSessionCapAge: test.consoleSessionCapAge})
+			if dbPool != nil {
+				defer dbPool.Close()
+			}
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer ts.Close()
+
+			// Initial login
+			_, sessionCookie := consoleLogin(t, ts.URL, test.username, test.password)
+
+			time.Sleep(test.sleepDuration)
+
+			// New client that does not use a cookie jar that will
+			// leave out expired cookies, we add the cookie
+			// manually to test server behavior
+			client := &http.Client{
+				// Do not automatically follow redirects so we
+				// can test the different cookie state outcomes
+				// based on initial server response.
+				CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+					return http.ErrUseLastResponse
+				},
+			}
+
+			req, err := http.NewRequest("GET", ts.URL+"/console", nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.AddCookie(&http.Cookie{
+				Name:  cookieName,
+				Value: sessionCookie.Value,
+			})
+
+			resp, err := client.Do(req) // #nosec G704
+			if err != nil {
+				t.Fatal(err)
+			}
+			defer resp.Body.Close()
+
+			if test.expectedLocation != "" {
+				if resp.Header.Get("Location") != test.expectedLocation {
+					t.Fatalf("unexpected Location header: have: '%s', want: '%s'", resp.Header.Get("Location"), test.expectedLocation)
+				}
+			}
+
+			if resp.StatusCode != test.expectedStatus {
+				t.Fatalf("unexpected status code: %d", resp.StatusCode)
+			}
+
+			// If the response was OK we want to verify the expires
+			// duration has been increased by sliding
+			if resp.StatusCode == http.StatusOK {
+				if sessionCookie.Expires.IsZero() {
+					t.Fatal("initial session cookie expires field is zero")
+				}
+
+				var sessionCookieNext *http.Cookie
+				for _, c := range resp.Cookies() {
+					if c.Name == cookieName {
+						sessionCookieNext = c
+					}
+				}
+
+				if sessionCookieNext.Expires.IsZero() {
+					t.Fatal("next session cookie expires field is zero")
+				}
+
+				if !sessionCookieNext.Expires.After(sessionCookie.Expires) {
+					t.Fatal("next session cookie expires field is not after initial session cookie")
+				}
+			}
+		})
+	}
 }

--- a/sunet-cdn-manager.toml.sample
+++ b/sunet-cdn-manager.toml.sample
@@ -2,6 +2,8 @@
 url = "https://manager.sunet-cdn.localhost:8444"
 addr = "127.0.0.1:8444"
 vcl_validation_url = "http://localhost:8888/validate-vcl"
+console_session_max_age = "1h"
+console_session_cap_age = "8h"
 
 [db]
 dbname = "cdn"


### PR DESCRIPTION
We were running with the default of not setting a MaxAge which meant that we got very long lived cookies. With this change the idea is that there is a hard limit of 8 hours until you need to reauthenticate, but there is also a shorter limit of 1 hour MaxAge where you will get logged out of you are inactive for this amount of time, but any activity will extend the validity for another hour (up until the 8 hour cap).

Reasoning about the current code led to a bit if refactoring where previously console handlers would all call getSession() and read out the authData from the CookieStore themselves, and this was done even if consoleAuthMiddleware() was already inserting the AuthData in the request context.

Now console handlers read out the existing AuthData from context instead, and we also store the session in the context in the same way. This makes it easier to reason about the lifetime of a given session and we no longer need to pass the CookieStore to all console handlers.