### PR TITLE
Do login page redirects with HX-Redirect for htmx

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -112,6 +112,7 @@ const (
 	// exclusion_violation: 23P01
 	pgExclusionViolation = "23P01"
 
+	authLoginPath                    = "/auth/login"
 	consolePath                      = "/console"
 	consoleSuperuserCacheNodes       = "/console/superuser/cache-nodes"
 	consoleSuperuserL4LBNodes        = "/console/superuser/l4lb-nodes"
@@ -3225,7 +3226,26 @@ func redirectToLoginPage(w http.ResponseWriter, r *http.Request, session *sessio
 		logger.Err(err).Msg("redirectToLoginPage: failed to save pending return-to in session")
 	}
 
-	validatedRedirect("/auth/login", w, r, http.StatusFound)
+	if r.Header.Get("HX-Request") != "" {
+		// This is a htmx request (probably due to the use of
+		// hx-boost). Instead of sending a normal redirect which would
+		// lead to htmx swapping the login page into the body instruct
+		// it to do a full reload of the whole page with a response header.
+		w.Header().Add("HX-Redirect", authLoginPath)
+
+		logger.Info().Msg("issuing HX-Redirect to login page")
+		// From https://htmx.org/headers/hx-redirect/
+		// ===
+		// Response headers are not processed on 3xx response codes.
+		// ===
+		_, err := fmt.Fprintf(w, "HX-Redirect header is set to '%s'", authLoginPath)
+		if err != nil {
+			logger.Err(err).Msg("redirectToLoginPage: unable to write HX-Redirect response")
+		}
+		return
+	}
+
+	validatedRedirect(authLoginPath, w, r, http.StatusFound)
 }
 
 func createLoginCacheKey(userID pgtype.UUID, expectedPasswordHash []byte, expectedSalt []byte, password string) string {

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -8180,6 +8180,42 @@ func TestConsoleDashboardRedirect(t *testing.T) {
 		}
 	})
 
+	// Verify that a GET for a specific URL while unauthenticated is
+	// redirected via HX-Redirect if sending a htmx request.
+	t.Run("superuser with org doing htmx request gets redirected back to requested page after auth via HX-Redirect", func(t *testing.T) {
+		client := &http.Client{
+			CheckRedirect: func(_ *http.Request, _ []*http.Request) error {
+				return http.ErrUseLastResponse
+			},
+		}
+
+		origGetPath := "/console/org/sunet/domains"
+
+		// Unauthenticated request
+		req, err := http.NewRequest("GET", ts.URL+origGetPath, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Mimic htmx request
+		req.Header.Set("HX-Request", "true")
+
+		// Initial GET returns 200 response with HX-Redirect set
+		getResp, err := client.Do(req) // #nosec G704
+		if err != nil {
+			t.Fatal(err)
+		}
+		getResp.Body.Close()
+
+		if getResp.StatusCode != http.StatusOK {
+			t.Fatalf("expected 200 from login with HX-Request, got %d", getResp.StatusCode)
+		}
+
+		if getResp.Header.Get("HX-Redirect") != authLoginPath {
+			t.Fatalf("expected HX-Redirect header with path '%s', got '%s'", authLoginPath, getResp.Header.Get("HX-Redirect"))
+		}
+	})
+
 	// Verify the redirect only fires once.
 	t.Run("superuser with org subsequent visit renders dashboard", func(t *testing.T) {
 		client, _ := consoleLogin(t, ts.URL, "admin-with-org", validAdminPassword)


### PR DESCRIPTION
When clicking a link in the UI with a expired session cookie I noticed I was redirect to a broken login page. This seems to be a result of hx-boost making htmx do the request, following the login page redirect and swapping the returned response into the body.

To make this behave better detect if we are receiving a request sent by htmx and in that case handle the redirect by setting a HX-Redirect reponse header instead.

Add test to check for the header as well.